### PR TITLE
Unassign existing groups (optionally leave them)

### DIFF
--- a/services/users.service.ts
+++ b/services/users.service.ts
@@ -361,9 +361,15 @@ export default class UsersService extends moleculer.Service {
         convert: true,
       },
       groups: 'array',
+      unassign: {
+        type: 'boolean',
+        default: true,
+      },
     },
   })
-  async assignGroups(ctx: Context<{ id: number; groups: Array<string> }, AppAuthMeta>) {
+  async assignGroups(
+    ctx: Context<{ id: number; groups: Array<string>; unassign: boolean }, AppAuthMeta>,
+  ) {
     const userId = ctx.params.id;
     if (!userId) return;
 
@@ -380,7 +386,7 @@ export default class UsersService extends moleculer.Service {
 
     if (everyGroupAssigned) return false;
 
-    this.assignNewGroupsToUser(newGroups, assignedGroups, ctx.meta);
+    this.assignNewGroupsToUser(newGroups, ctx.params.unassign ? assignedGroups : [], ctx.meta);
     return true;
   }
 

--- a/services/usersLocal.service.ts
+++ b/services/usersLocal.service.ts
@@ -214,6 +214,10 @@ export default class UsersLocalService extends moleculer.Service {
           },
         },
       },
+      unassignExistingGroups: {
+        type: 'boolean',
+        default: true,
+      },
     },
   })
   async invite(
@@ -231,6 +235,7 @@ export default class UsersLocalService extends moleculer.Service {
         password: string;
         apps: number[];
         doNotSendEmail: boolean;
+        unassignExistingGroups: boolean;
       },
       AppAuthMeta & UserAuthMeta
     >,
@@ -243,7 +248,7 @@ export default class UsersLocalService extends moleculer.Service {
       ctx.params.apps = [appId];
     }
 
-    const { email, groups, password, apps } = ctx.params;
+    const { email, groups, password, apps, unassignExistingGroups } = ctx.params;
 
     const userLocal: UserLocal = await ctx.call('usersLocal.findOrCreate', {
       email,
@@ -271,6 +276,7 @@ export default class UsersLocalService extends moleculer.Service {
       const hasGroupChanges = await ctx.call('users.assignGroups', {
         id: userLocal.user,
         groups,
+        unassign: !!unassignExistingGroups,
       });
 
       if (!hasGroupChanges) {
@@ -345,6 +351,10 @@ export default class UsersLocalService extends moleculer.Service {
           },
         },
       },
+      unassignExistingGroups: {
+        type: 'boolean',
+        default: true,
+      },
     },
   })
   async updateUser(
@@ -363,11 +373,12 @@ export default class UsersLocalService extends moleculer.Service {
           role: UserGroupRole;
         }>;
         apps: string[];
+        unassignExistingGroups: boolean;
       },
       AppAuthMeta & UserAuthMeta
     >,
   ) {
-    const { id, groups, password, oldPassword, email } = ctx.params;
+    const { id, groups, password, oldPassword, email, unassignExistingGroups } = ctx.params;
     let user: User = await ctx.call('users.resolve', { id });
 
     const { meta } = ctx;
@@ -417,6 +428,7 @@ export default class UsersLocalService extends moleculer.Service {
         {
           id,
           groups,
+          unassign: !!unassignExistingGroups,
         },
         { meta },
       );


### PR DESCRIPTION
Before this - if you call `POST /users` or `PATCH /users/:id` groups used to be removed (those which were not passed).

After this change, you can pass `unassignExistingGroups: false` as parameter to leave old groups in place.

**Example:**
Before: If you call `groups: [{id: 1, role: 'USER'}]` - if user existed in group with ID 2, user is removed from that group, leaving user only in group 1.

After: If you call `groups: [{id: 1, role: 'USER'}], unassignExistingGroups: false` - if user existed in any other group - he/she will be left in that group without removing (unassigning)

However, keep in mind, that before this change user was removed only from visible groups (for that specific user). This change only works as toggle only. This means - if user was in group 1, group 2, group 3 (updating/creating without `unassignExistingGroups` parameter) if "admin" that can make changes to that user only sees group 1 and group 2, user was not removed from group 3 (it's not visible for them). 


✅ Tests (4) for invite and update were written to test this parameter