### PR TITLE
Allow FA_<personalCode> as companyCode for natural persons

### DIFF
--- a/services/groups.service.ts
+++ b/services/groups.service.ts
@@ -18,8 +18,7 @@ import {
   throwValidationError,
 } from '../types';
 
-import { companyCode as companyCodeChecker } from 'lt-codes';
-
+import { isValidCompanyCode } from '../utils';
 import { toggleItemInArray } from '../utils/array';
 import { AppAuthMeta, UserAuthMeta } from './api.service';
 import { App } from './apps.service';
@@ -748,9 +747,7 @@ export default class GroupsService extends moleculer.Service {
         return `Company with company code '${value}' already exists.`;
       }
 
-      const { isValid } = companyCodeChecker.validate(value);
-
-      if (!isValid) return 'Invalid company code';
+      if (!isValidCompanyCode(value)) return 'Invalid company code';
     }
 
     return true;

--- a/services/usersEvartai.service.ts
+++ b/services/usersEvartai.service.ts
@@ -3,7 +3,7 @@
 import moleculer, { Context } from 'moleculer';
 import { Action, Method, Service } from 'moleculer-decorators';
 
-import { companyCode as companyCodeChecker, personalCode as personalCodeChecker } from 'lt-codes';
+import { personalCode as personalCodeChecker } from 'lt-codes';
 
 import DbConnection from '../mixins/database.mixin';
 import {
@@ -15,7 +15,12 @@ import {
   throwBadRequestError,
   throwNotFoundError,
 } from '../types';
-import { emailCanBeSent, normalizeName, sendEvartaiInvitationEmail } from '../utils';
+import {
+  emailCanBeSent,
+  isValidCompanyCode,
+  normalizeName,
+  sendEvartaiInvitationEmail,
+} from '../utils';
 import { AppAuthMeta, UserAuthMeta } from './api.service';
 import { App } from './apps.service';
 import { Group } from './groups.service';
@@ -327,8 +332,7 @@ export default class UsersEvartaiService extends moleculer.Service {
     }
 
     if (companyCode) {
-      const { isValid } = companyCodeChecker.validate(companyCode);
-      if (!isValid) {
+      if (!isValidCompanyCode(companyCode)) {
         throw new moleculer.Errors.ValidationError(
           `Company code '${companyCode}' is invalid.`,
           'AUTH_INVALID_COMPANY_CODE',
@@ -387,11 +391,9 @@ export default class UsersEvartaiService extends moleculer.Service {
           if (!throwErrors) return returnData;
 
           // company code is invalid for custom app groups
-          const { isValid: isValidCompanyCode } = companyCodeChecker.validate(company.companyCode);
-
           throw new moleculer.Errors.ValidationError(
             `User already assigned to '${companyId}' company.`,
-            isValidCompanyCode ? 'AUTH_USER_ASSIGNED' : 'AUTH_USER_EXISTS',
+            isValidCompanyCode(company.companyCode) ? 'AUTH_USER_ASSIGNED' : 'AUTH_USER_EXISTS',
           );
         }
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,7 +1,20 @@
+import { companyCode as companyCodeChecker, personalCode as personalCodeChecker } from 'lt-codes';
+
 export * from './tokens';
 export * from './hashes';
 export * from './mails';
 export * from './recaptcha';
+
+// Convention: a natural person acting as a company uses 'FA_<personalCode>'.
+const FA_COMPANY_CODE_REGEX = /^FA_(\d{11})$/;
+
+export const isValidCompanyCode = (code: string): boolean => {
+  if (!code) return false;
+  if (companyCodeChecker.validate(code).isValid) return true;
+  const match = FA_COMPANY_CODE_REGEX.exec(code);
+  if (match) return personalCodeChecker.validate(match[1]).isValid;
+  return false;
+};
 
 export const normalizeName = (words: string) => {
   if (!words) return;


### PR DESCRIPTION
## Kontekstas

Kai kuriuose srautuose reikalingas fizinis asmuo, veikiantis kaip įmonė. Yra istoriškai susitarta konvencija — tokiu atveju `companyCode` įvedamas formatu `FA_<asmens kodas>` (11 skaitmenų).

Iki šiol validacija (`lt-codes` `companyCode.validate`) priimdavo tik 9 skaitmenų įmonės kodą, todėl bandant kviestis tokį asmenį backend'as gražindavo:

```
AuthError 422 — AUTH_INVALID_COMPANY_CODE
"Company code 'FA_36304230142' is invalid."
```

Prod DB egzistuoja senesnių tokių įrašų, įvestų apeinant API tiesiai per DB.

## Pakeitimai

- Pridėtas bendras helper'is `isValidCompanyCode` (`utils/index.ts`):
  - praleidžia įprastą galiojantį 9-ženklį įmonės kodą,
  - papildomai praleidžia `FA_<11 skaitm.>`, kai sufiksas yra galiojantis Lietuvos asmens kodas pagal `lt-codes` `personalCode.validate`.
- `services/usersEvartai.service.ts` — invite srautas naudoja naują helper'į (`AUTH_INVALID_COMPANY_CODE` ir `AUTH_USER_ASSIGNED` / `AUTH_USER_EXISTS` šakų sprendimas).
- `services/groups.service.ts` — field-level `validateCompanyCode` modelyje naudoja tą patį helper'į.

Atgaliniai suderinami: visi galiojantys 9-ženkliai kodai praeina kaip ir anksčiau; tik praplečiama priimamų reikšmių aibė.

## Test plan

- [ ] `users.invite` su `companyCode: "FA_<galiojantis asmens kodas>"` — sukuriamas tenant'as, klaidos negrąžina.
- [ ] `users.invite` su `companyCode: "FA_00000000000"` (negaliojantis asmens kodas sufikse) — grąžina `AUTH_INVALID_COMPANY_CODE`.
- [ ] `users.invite` su galiojančiu 9-ženkliu įmonės kodu — kaip iki šiol veikia.
- [ ] `groups.create` / update su `companyCode: "FA_<...>"` per admin srautą — praeina validaciją.
- [ ] Esami integration testai (`test/integration/api/users/users.invite.spec.ts` ir kt.) toliau praeina.

🤖 Generated with [Claude Code](https://claude.com/claude-code)