### PR TITLE
Pin lt-codes to AplinkosMinisterija fork v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "jsonwebtoken": "^9.0.1",
     "knex": "^2.5.1",
     "lodash": "^4.17.21",
-    "lt-codes": "github:ambrazasp/lt-codes",
+    "lt-codes": "github:AplinkosMinisterija/lt-codes#v1.1.2",
     "moleculer": "^0.14.20",
     "moleculer-auto-openapi": "^1.1.3",
     "moleculer-db": "^0.8.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3874,9 +3874,9 @@ lru-queue@0.1:
   dependencies:
     es5-ext "~0.10.2"
 
-"lt-codes@github:ambrazasp/lt-codes":
-  version "1.0.0"
-  resolved "https://codeload.github.com/ambrazasp/lt-codes/tar.gz/a3dd47207f1f1a8cc94ecd300b59c0af189351bf"
+"lt-codes@github:AplinkosMinisterija/lt-codes#v1.1.2":
+  version "1.1.2"
+  resolved "https://codeload.github.com/AplinkosMinisterija/lt-codes/tar.gz/9938111ffa8212cfccda00938c5a502cd7f4bc97"
   dependencies:
     moment "^2.29.4"
 


### PR DESCRIPTION
## Kontekstas

Pagal AM susitarimą — kai įmonės vietoje veikia fizinis asmuo, į \`companyCode\` lauką įrašoma \`FA_<11-ženklis asmens kodas>\`. Iki šiol prod DB tokių įrašų buvo, bet jie patekdavo apeinant API tiesiai per DB, nes \`companyCode.validate()\` iš \`ambrazasp/lt-codes\` priimdavo tik 9-ženklį Lietuvos registro kodą:

\`\`\`
AuthError 422 — AUTH_INVALID_COMPANY_CODE
"Company code 'FA_36304230142' is invalid."
\`\`\`

## Pakeitimai

\`package.json\`:
- \`"lt-codes": "github:ambrazasp/lt-codes"\` (commit \`a3dd472\`, 2022-11)
- → \`"lt-codes": "github:AplinkosMinisterija/lt-codes#v1.1.2"\`

\`yarn.lock\` atnaujintas atitinkamai (3 eilutės). Jokių kodo pakeitimų — tiek invite srautas (\`services/usersEvartai.service.ts:329\`), tiek field-level grupių validacija (\`services/groups.service.ts:739\`) kviečia \`companyCode.validate(...)\`, ir fork'as natūraliai supranta \`FA_\` formą.

## Susiję PR'ai

- Fork: AplinkosMinisterija/lt-codes#3 (FA_ logika)
- Fork build fix: AplinkosMinisterija/lt-codes#5 (\`dist/\` shipping)
- Release: https://github.com/AplinkosMinisterija/lt-codes/releases/tag/v1.1.2

## Test plan

- [ ] \`yarn install\` — \`node_modules/lt-codes/dist/index.js\` egzistuoja.
- [ ] Smoke: \`node -e "console.log(require('lt-codes').companyCode.validate('FA_36304230142'))"\` → \`{ isValid: true, isException: true }\`.
- [ ] \`yarn build\` praeina.
- [ ] \`users.invite\` (admin tenant invite) su \`companyCode: "FA_<galiojantis asmens kodas>"\` — sukuria tenant'ą.
- [ ] Esami integration testai praeina (\`test/integration/api/users/users.invite.spec.ts\`).
- [ ] Paliečiamas anksčiau atidarytas PR #42 — uždarytas, jį pakeičia šis (FA_ logika perkelta į lib'ą).

🤖 Generated with [Claude Code](https://claude.com/claude-code)