### PR TITLE
Stop hammering auth on every login

### DIFF
--- a/moleculer.config.ts
+++ b/moleculer.config.ts
@@ -78,7 +78,9 @@ const brokerConfig: BrokerOptions = {
   serializer: 'JSON',
 
   // Number of milliseconds to wait before reject a request with a RequestTimeout error. Disabled: 0
-  requestTimeout: 10 * 1000,
+  // Bumped from 10s to give the slow inherited_user_apps view headroom under
+  // load while we work on materializing it. Recalibrate once we have data.
+  requestTimeout: 30 * 1000,
 
   // Retry policy settings. More info: https://moleculer.services/docs/0.14/fault-tolerance.html#Retry
   retryPolicy: {

--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -56,7 +56,7 @@ export default class AuthService extends moleculer.Service {
 
     const user = await this.getValidatedUser(id, ctx.meta.app);
 
-    await ctx.call('users.update', { id: user.id, lastLoggedInAt: new Date() });
+    await ctx.call('users.updateLastLogin', { id: user.id });
     // TODO: save refresh token to check in refresh
     return this.generateToken(user, AuthStrategy.LOCAL, strategyId, refresh);
   }
@@ -137,7 +137,7 @@ export default class AuthService extends moleculer.Service {
 
     const user = await this.getValidatedUser(id, ctx.meta.app);
 
-    await ctx.call('users.update', { id: user.id, lastLoggedInAt: new Date() });
+    await ctx.call('users.updateLastLogin', { id: user.id });
 
     return this.generateToken(user, AuthStrategy.EVARTAI, strategyId, refresh);
   }
@@ -169,7 +169,7 @@ export default class AuthService extends moleculer.Service {
 
     const user = await this.getValidatedUser(id, ctx.meta.app);
 
-    await ctx.call('users.update', { id: user.id, lastLoggedInAt: new Date() });
+    await ctx.call('users.updateLastLogin', { id: user.id });
 
     return this.generateToken(user, strategy, strategyId, true);
   }
@@ -264,20 +264,19 @@ export default class AuthService extends moleculer.Service {
   })
   async parseToken(ctx: Context<{ token: string }, AppAuthMeta>) {
     const token = ctx.params.token;
-    try {
-      const result: any = await verifyToken(token);
-      if (result && result.id) {
-        await this.broker.call('permissions.validatePermissionToAccessApp', {
-          appId: ctx.meta.app.id,
-          userId: result.id,
-        });
+    // Don't catch — moleculer caches successful returns. If we cached `{}` on a
+    // transient DB timeout in validatePermissionToAccessApp, the user would be
+    // locked out for the full TTL. Letting the error propagate keeps the cache
+    // empty so the next request retries.
+    const result: any = await verifyToken(token);
+    if (!result || !result.id) return {};
 
-        return result;
-      }
-    } catch (e) {
-      this.logger.error('Error resolving token', token, e);
-    }
-    return {};
+    await this.broker.call('permissions.validatePermissionToAccessApp', {
+      appId: ctx.meta.app.id,
+      userId: result.id,
+    });
+
+    return result;
   }
 
   @Action({

--- a/services/permissions.service.ts
+++ b/services/permissions.service.ts
@@ -597,6 +597,12 @@ export default class PermissionsService extends moleculer.Service {
     });
   }
 
+  // Hot path: called via `auth.parseToken` on every authenticated request when
+  // the parseToken cache misses. Keep this lightweight — query inheritedUserApps
+  // directly instead of resolving the full user with inheritedApps populate
+  // (which N+1's apps.resolve and forces an extra hop through the user record).
+  // Cache enabled to absorb thundering herds; cleaned via `cacheCleanEvents`
+  // above when the underlying permissions actually change.
   @Action({
     params: {
       userId: {
@@ -608,24 +614,19 @@ export default class PermissionsService extends moleculer.Service {
         convert: true,
       },
     },
-    // cache: {
-    //   keys: ['userId', 'appId'],
-    // },
+    cache: {
+      keys: ['userId', 'appId'],
+      ttl: 60 * 5,
+    },
   })
   async validatePermissionToAccessApp(ctx: Context<{ userId: number; appId: number }>) {
-    const app: App = await ctx.call('apps.resolve', { id: ctx.params.appId });
-    const user: User = await ctx.call('users.resolve', {
-      id: ctx.params.userId,
-      populate: 'inheritedApps',
+    const { userId, appId } = ctx.params;
+
+    const appsIds: number[] = await ctx.call('inheritedUserApps.getAppsByUser', {
+      user: userId,
     });
 
-    if (!app || !user) {
-      throwNotFoundError('App not found');
-    }
-
-    const hasApp = user.inheritedApps.some((a: App) => a.id == app.id);
-
-    if (!hasApp) {
+    if (!appsIds?.some((id) => id == appId)) {
       throwUnauthorizedError('Unauthorized to access app');
     }
 

--- a/services/users.service.ts
+++ b/services/users.service.ts
@@ -258,7 +258,8 @@ export default class UsersService extends moleculer.Service {
 
   // Bypasses updateEntity so no `users.updated` event fires — that event would
   // bust permissions cache for ALL users on every login (see permissions.service
-  // cacheCleanEvents).
+  // cacheCleanEvents). Caller must have already validated the user exists;
+  // adapter.updateById skips default scopes (notDeleted) and field validation.
   @Action({
     params: {
       id: 'number|convert',

--- a/services/users.service.ts
+++ b/services/users.service.ts
@@ -256,6 +256,20 @@ export default class UsersService extends moleculer.Service {
     return !!(user && user.id);
   }
 
+  // Bypasses updateEntity so no `users.updated` event fires — that event would
+  // bust permissions cache for ALL users on every login (see permissions.service
+  // cacheCleanEvents).
+  @Action({
+    params: {
+      id: 'number|convert',
+    },
+  })
+  async updateLastLogin(ctx: Context<{ id: number }>) {
+    const adapter = await this.getAdapter(ctx);
+    await adapter.updateById(ctx.params.id, { lastLoggedInAt: new Date() });
+    return { success: true };
+  }
+
   /**
    * Get user by JWT token (for API GW authentication)
    */


### PR DESCRIPTION
## Problem

Production auth-api was returning cascading `401 INVALID_TOKEN` to valid JWTs after `biip-zvejyba-api` 1.3.6 deploys. Container restart fixed it temporarily but it reoccurred.

Logs showed:
```
RequestTimeoutError: Request is timed out when call 'permissions.validatePermissionToAccessApp'
```

Root causes (interacting):

1. **`auth.parseToken` cached failures.** When `validatePermissionToAccessApp` timed out (10s broker timeout), `parseToken` swallowed the error and returned `{}`, which Moleculer cached for the full 1h TTL — locking the user out long after DB recovered.
2. **Permissions cache busted on every login.** `users.update({ lastLoggedInAt: new Date() })` fires `users.updated`, which `permissions.service` cacheCleanEvents wipes — clearing cache for **every** user every time **any** user logs in.
3. **`validatePermissionToAccessApp` did extra work.** Resolved the full user with `populate: 'inheritedApps'` (which N+1's `apps.resolve` per app), instead of querying `inheritedUserApps` directly. Cache that was meant to cushion this was commented out.

The žvejyba 1.3.6 release didn't *cause* the bug — it added load (more tenants, more `userGroups.created` events, more logins) that exposed the existing performance cliff.

## Changes

- **`users.updateLastLogin`** — new action that calls `adapter.updateById` directly, bypassing `updateEntity` so no `users.updated` event fires. Used by all 3 login paths (local, evartai, refreshToken).
- **`validatePermissionToAccessApp`** — replaced the `apps.resolve` + `users.resolve(populate: 'inheritedApps')` chain with a single `inheritedUserApps.getAppsByUser` call. Re-enabled cache (`['userId', 'appId']`, 5 min TTL); existing `cacheCleanEvents` already invalidate on real permission changes.
- **`parseToken`** — removed the silent try/catch. Errors now propagate; `api.service` already converts them to `UnAuthorizedError` (401), but the failed result no longer poisons the cache.

## Not in this PR (deliberate)

- **Materialize `inherited_user_apps` view.** It's a regular view over a recursive CTE; `WHERE user_id = ?` doesn't push down well. Real fix needs a materialized view + GIN index + refresh strategy. Worth a separate, careful migration.
- **DB pool size.** `knexfile.ts` has `pool: { max: 10 }`. Likely too low for prod traffic but want to size with metrics.
- **`cache.lock` on `parseToken`** — would prevent thundering herd on cache miss; needs Moleculer cacher config.

## Test plan

- [ ] Deploy to staging, verify login + `/api/users/me` flow works
- [ ] Trigger logins from multiple users, confirm `permissions.cache.clean` events drop sharply (Prometheus / Redis MONITOR)
- [ ] Watch staging error logs for `RequestTimeoutError` on `validatePermissionToAccessApp`
- [ ] Have someone deploy a žvejyba release to staging — auth should stay healthy