### PR TITLE
Fix POST /api/users/:userId/impersonate 404

### DIFF
--- a/services/api.service.ts
+++ b/services/api.service.ts
@@ -137,7 +137,9 @@ function verifyApiKey(
         // The gateway will dynamically build the full routes from service schema.
         autoAliases: true,
 
-        aliases: {},
+        aliases: {
+          'POST /users/:userId/impersonate': 'auth.impersonateUser',
+        },
 
         // Enable authentication. Implement the logic into `authenticate` method. More info: https://moleculer.services/docs/0.14/moleculer-web.html#Authentication
         authentication: true,


### PR DESCRIPTION
## Summary
- The `auth.impersonateUser` action declares `rest: { method: 'POST', path: '/:userId/impersonate', basePath: '/users' }`, but moleculer-web 0.10.4 autoAliases fails to register this combination under the `/api` route — calling `POST /api/users/40/impersonate` returns `ServiceNotFoundError` (mappingPolicy `'all'` fallback tries to resolve `users.40.impersonate`).
- Manually adding the alias under the `/api` route's `aliases` exposes the existing action at the URL that `biip-auth-nodejs` SDK (used by zuvinimas/medziokle/zvejyba/rusys) already expects: `POST /api/users/{id}/impersonate`.
- No changes to action name, params, or `types: [EndpointType.SUPER_ADMIN]` enforcement — old SDK consumers keep working unchanged.

## Test plan
- [ ] After deploy: `POST /api/users/:userId/impersonate` with valid SUPER_ADMIN token + `X-API-Key` returns the impersonated user's token.
- [ ] Without token → 401 (`ERR_NO_TOKEN`), not 404.
- [ ] With non-super-admin token → 401 (`ERR_INVALID_TOKEN`), confirming `types: [EndpointType.SUPER_ADMIN]` still enforced.
- [ ] Other auth-api endpoints (login, users CRUD, etc.) unaffected — only one alias added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)