### PR TITLE
feat(auth): audit log on user impersonation

### DIFF
--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -76,7 +76,7 @@ export default class AuthService extends moleculer.Service {
     },
     types: [EndpointType.SUPER_ADMIN],
   })
-  async impersonateUser(ctx: Context<{ userId: number }, AppAuthMeta>) {
+  async impersonateUser(ctx: Context<{ userId: number }, AppAuthMeta & UserAuthMeta>) {
     const { userId } = ctx.params;
 
     const user: User = await this.getValidatedUser(userId, ctx.meta.app);
@@ -106,6 +106,13 @@ export default class AuthService extends moleculer.Service {
     if (!strategy || !strategyId) {
       return throwNotFoundError('User strategy not found.');
     }
+
+    this.logger.warn('IMPERSONATE', {
+      actor: { id: ctx.meta.user?.id, email: ctx.meta.user?.email },
+      target: { id: user.id, email: user.email },
+      app: ctx.meta.app?.id,
+      strategy,
+    });
 
     return this.generateToken(user, strategy, strategyId, false);
   }


### PR DESCRIPTION
## Summary
- Logs actor, target, and strategy whenever a super-admin impersonates another user.
- Pairs with the new impersonate flow being added to `biip-admin-web` and `biip-medziokle-web`.

## Test plan
- [ ] Trigger impersonate from admin-web, confirm a warn-level `IMPERSONATE` entry appears in auth-api logs with actor/target IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)