### PR TITLE
fix(security): authz hardening — permissions escalation, PII scope, evartai, login throttle

### DIFF
--- a/services/api.service.ts
+++ b/services/api.service.ts
@@ -198,6 +198,9 @@ export default class ApiService extends moleculer.Service {
   ): Promise<unknown> {
     const meta = ctx.meta as any;
     if (meta.user || meta.app) {
+      // Do NOT log raw `params`, `meta`, or `locals`: meta carries the bearer
+      // `authToken` and params can carry credentials/PII. Log only identifiers
+      // needed to trace the failure.
       const context = pick(
         ctx,
         'nodeID',
@@ -209,18 +212,15 @@ export default class ApiService extends moleculer.Service {
         'parentID',
         'requestID',
         'caller',
-        'params',
-        'meta',
-        'locals',
       );
-      const action = pick(ctx.action, 'rawName', 'name', 'params', 'rest');
+      const action = pick(ctx.action, 'rawName', 'name', 'rest');
       const logInfo = {
         action: 'AUTH_FAILURE',
         details: {
           error,
           context,
           action,
-          meta,
+          meta: { userId: meta.user?.id, appId: meta.app?.id },
         },
       };
       this.logger.error(logInfo);
@@ -353,8 +353,10 @@ export default class ApiService extends moleculer.Service {
 
   @Action({
     rest: 'POST /cache/clean',
-
-    auth: EndpointType.PUBLIC,
+    // Flushing the whole Redis cacher forces the heavy inherited_user_apps view
+    // scan on every subsequent request (service-wide brownout). Restrict to
+    // SUPER_ADMIN — was previously PUBLIC, i.e. any app API key could DoS auth.
+    types: [EndpointType.SUPER_ADMIN],
   })
   cleanCache() {
     this.broker.cacher.clean();

--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -47,12 +47,25 @@ export default class AuthService extends moleculer.Service {
       AppAuthMeta
     >,
   ) {
-    const { email, password, refresh } = ctx.params;
+    const { password, refresh } = ctx.params;
+    const email = ctx.params.email.toLowerCase();
 
-    const { userId: strategyId, id }: any = await ctx.call('usersLocal.validateLogin', {
-      email: email.toLowerCase(),
-      password,
-    });
+    await this.assertLoginNotRateLimited(email);
+
+    let strategyId: number;
+    let id: number;
+    try {
+      const validated: any = await ctx.call('usersLocal.validateLogin', {
+        email,
+        password,
+      });
+      strategyId = validated.userId;
+      id = validated.id;
+    } catch (err) {
+      await this.registerFailedLogin(email);
+      throw err;
+    }
+    await this.clearFailedLogins(email);
 
     const user = await this.getValidatedUser(id, ctx.meta.app);
 
@@ -305,10 +318,11 @@ export default class AuthService extends moleculer.Service {
   })
   async logout(ctx: Context<{}, AppAuthMeta & UserAuthMeta>) {
     const { authToken: token } = ctx.meta;
-    const valid = await ctx.call('auth.parseToken', { token }, { meta: ctx.meta });
-    if (!valid) return { success: false };
+    // parseToken returns `{}` (truthy) for an invalid/expired token, so guard on
+    // the decoded id. Never log the raw bearer token.
+    const valid: any = await ctx.call('auth.parseToken', { token }, { meta: ctx.meta });
+    if (!valid?.id) return { success: false };
 
-    console.log('user logout', token);
     return { success: true };
   }
 
@@ -465,6 +479,18 @@ export default class AuthService extends moleculer.Service {
   // Path-aware: when the registered app.url includes a pathname, the target
   // must live under it. Stops chaining through any redirect endpoint that a
   // trusted app might host at an unrelated path.
+  // Broker-only (no `rest`, so not HTTP-exposed) wrapper around the redirect
+  // allow-list so sibling services (e.g. usersEvartai.sign) can validate a
+  // caller-supplied host without duplicating the apps-allow-list logic.
+  @Action({
+    params: {
+      target: 'string',
+    },
+  })
+  async isRedirectAllowed(ctx: Context<{ target: string }>) {
+    return this.isAllowedRedirectTarget(ctx.params.target);
+  }
+
   @Method
   async isAllowedRedirectTarget(target: string): Promise<boolean> {
     if (!target || typeof target !== 'string') return false;
@@ -555,6 +581,59 @@ export default class AuthService extends moleculer.Service {
           error: e?.message,
         }),
       );
+  }
+
+  // ---- Login brute-force throttle ----------------------------------------
+  // Keyed per email; counts only failed password attempts within a rolling
+  // window and clears on success. `remindPassword` already self-throttles per
+  // user, so only the password-login path needs this. Backed by the Redis
+  // cacher (no-op if the cacher is absent).
+
+  @Method
+  loginAttemptsKey(email: string) {
+    return `auth.loginAttempts:${email}`;
+  }
+
+  @Method
+  loginRateLimitEnabled() {
+    // Enabled in real environments; off in the test env unless explicitly turned
+    // on, so accumulated attempts don't perturb the existing suite.
+    if (process.env.NODE_ENV === 'test') return process.env.ENABLE_LOGIN_RATE_LIMIT === 'true';
+    return true;
+  }
+
+  @Method
+  async assertLoginNotRateLimited(email: string) {
+    if (!this.loginRateLimitEnabled()) return;
+    const cacher = this.broker.cacher;
+    if (!cacher) return;
+    const data: any = await cacher.get(this.loginAttemptsKey(email));
+    const max = Number(process.env.LOGIN_MAX_ATTEMPTS) || 10;
+    if (data?.count >= max) {
+      throw new moleculer.Errors.MoleculerClientError(
+        'Too many failed login attempts. Try again later.',
+        429,
+        'TOO_MANY_ATTEMPTS',
+      );
+    }
+  }
+
+  @Method
+  async registerFailedLogin(email: string) {
+    if (!this.loginRateLimitEnabled()) return;
+    const cacher = this.broker.cacher;
+    if (!cacher) return;
+    const key = this.loginAttemptsKey(email);
+    const windowSec = Number(process.env.LOGIN_ATTEMPTS_WINDOW) || 300;
+    const data: any = (await cacher.get(key)) || { count: 0 };
+    data.count = (data.count || 0) + 1;
+    await cacher.set(key, data, windowSec);
+  }
+
+  @Method
+  async clearFailedLogins(email: string) {
+    if (!this.loginRateLimitEnabled()) return;
+    await this.broker.cacher?.del(this.loginAttemptsKey(email));
   }
 
   @Method

--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -479,16 +479,42 @@ export default class AuthService extends moleculer.Service {
   // Path-aware: when the registered app.url includes a pathname, the target
   // must live under it. Stops chaining through any redirect endpoint that a
   // trusted app might host at an unrelated path.
-  // Broker-only (no `rest`, so not HTTP-exposed) wrapper around the redirect
-  // allow-list so sibling services (e.g. usersEvartai.sign) can validate a
-  // caller-supplied host without duplicating the apps-allow-list logic.
+  // Broker-only wrapper used by usersEvartai.sign to validate the caller-supplied
+  // host. Matches at ORIGIN level (protocol+host) only: `sign` just forwards
+  // `host` to eVartai to build the return URL, so origin confinement already
+  // closes the off-domain ticket-delivery (account-takeover) vector, while
+  // tolerating registered app URLs that carry a path (e.g.
+  // https://gyvunai.biip.lt/app) which a strict path-prefix match would reject.
+  // The strict path-aware check (isAllowedRedirectTarget) stays on
+  // redirectEvartai's actual 302. `visibility: 'protected'` keeps this off the
+  // HTTP gateway — under mappingPolicy:'all' it would otherwise be reachable as
+  // `POST /api/auth/isRedirectAllowed`, i.e. an allow-list oracle.
   @Action({
+    visibility: 'protected',
     params: {
       target: 'string',
     },
   })
   async isRedirectAllowed(ctx: Context<{ target: string }>) {
-    return this.isAllowedRedirectTarget(ctx.params.target);
+    return this.isAllowedRedirectOrigin(ctx.params.target);
+  }
+
+  @Method
+  async isAllowedRedirectOrigin(target: string): Promise<boolean> {
+    if (!target || typeof target !== 'string') return false;
+    let targetUrl: URL;
+    try {
+      targetUrl = new URL(target);
+    } catch {
+      return false;
+    }
+    if (targetUrl.protocol !== 'http:' && targetUrl.protocol !== 'https:') {
+      return false;
+    }
+    const allowedOrigins = await this.getAllowedRedirectOrigins();
+    return allowedOrigins.some(
+      (allowed) => allowed.protocol === targetUrl.protocol && allowed.host === targetUrl.host,
+    );
   }
 
   @Method
@@ -607,7 +633,17 @@ export default class AuthService extends moleculer.Service {
     if (!this.loginRateLimitEnabled()) return;
     const cacher = this.broker.cacher;
     if (!cacher) return;
-    const data: any = await cacher.get(this.loginAttemptsKey(email));
+    let data: any;
+    try {
+      data = await cacher.get(this.loginAttemptsKey(email));
+    } catch (err) {
+      // Fail OPEN: a cacher/Redis outage must not take down login. Skip the
+      // throttle for this request rather than 500 every authentication.
+      this.logger.warn('Login throttle read failed; allowing login', err);
+      return;
+    }
+    // NB: the 429 throw stays OUTSIDE the try/catch above — a genuine rate-limit
+    // block must propagate, not be swallowed as a cacher error.
     const max = Number(process.env.LOGIN_MAX_ATTEMPTS) || 10;
     if (data?.count >= max) {
       throw new moleculer.Errors.MoleculerClientError(
@@ -625,15 +661,26 @@ export default class AuthService extends moleculer.Service {
     if (!cacher) return;
     const key = this.loginAttemptsKey(email);
     const windowSec = Number(process.env.LOGIN_ATTEMPTS_WINDOW) || 300;
-    const data: any = (await cacher.get(key)) || { count: 0 };
-    data.count = (data.count || 0) + 1;
-    await cacher.set(key, data, windowSec);
+    try {
+      const data: any = (await cacher.get(key)) || { count: 0 };
+      data.count = (data.count || 0) + 1;
+      await cacher.set(key, data, windowSec);
+    } catch (err) {
+      // Fail OPEN: throttle bookkeeping must never mask the real login error.
+      this.logger.warn('Login throttle write failed', err);
+    }
   }
 
   @Method
   async clearFailedLogins(email: string) {
     if (!this.loginRateLimitEnabled()) return;
-    await this.broker.cacher?.del(this.loginAttemptsKey(email));
+    try {
+      await this.broker.cacher?.del(this.loginAttemptsKey(email));
+    } catch (err) {
+      // Fail OPEN: a failed counter-clear must not turn a successful login (auth
+      // already passed) into a 500.
+      this.logger.warn('Login throttle clear failed', err);
+    }
   }
 
   @Method

--- a/services/groups.service.ts
+++ b/services/groups.service.ts
@@ -354,7 +354,11 @@ export default class GroupsService extends moleculer.Service {
     return mapIdRecursively(groups);
   }
 
-  @Action()
+  @Action({
+    // Wraps groups.create — mirror its gate. Reachable by name under the gateway's
+    // mappingPolicy:'all', so it must be type-gated like create/update/remove.
+    types: [EndpointType.ADMIN, EndpointType.SUPER_ADMIN],
+  })
   async findOrCreate(ctx: Context<{ companyCode: string }, AppAuthMeta>) {
     const group: Group = await ctx.call('groups.findOne', {
       query: ctx.params,
@@ -375,6 +379,9 @@ export default class GroupsService extends moleculer.Service {
   }
 
   @Action({
+    // Mutates a group's app assignment. No HTTP caller (internal usersEvartai
+    // flows only); SUPER_ADMIN-gate against the mappingPolicy:'all' bypass.
+    types: [EndpointType.SUPER_ADMIN],
     params: {
       id: {
         type: 'number',
@@ -506,7 +513,11 @@ export default class GroupsService extends moleculer.Service {
   }
 
   @Action({
+    // This is the real `DELETE /api/groups/:id` handler (the mixin `remove` is
+    // rest:null). It was type-less — any authenticated USER could delete any
+    // group. Admin screens delete groups as ADMIN, so gate ADMIN+SUPER_ADMIN.
     rest: 'DELETE /:id',
+    types: [EndpointType.ADMIN, EndpointType.SUPER_ADMIN],
     params: {
       id: {
         type: 'number',

--- a/services/permissions.service.ts
+++ b/services/permissions.service.ts
@@ -138,12 +138,15 @@ interface PermissionType {
     // raw CRUD surface must NOT be reachable by ordinary users: an authenticated
     // USER could otherwise `PATCH /api/permissions/:id {accesses:["*"]}` to grant
     // themselves anything (privilege escalation), or enumerate every permission
-    // via `GET /api/permissions`. Mutations go through the explicit, ADMIN-typed
-    // `findOrCreate` / `modifyAccessForGroup` actions instead; internal broker
-    // calls (e.g. from findUsersByAccess) keep working because `rest: null` only
-    // drops the HTTP alias, not the action.
+    // via `GET /api/permissions`. NOTE: under the gateway's `mappingPolicy: 'all'`,
+    // `rest: null` is NOT sufficient — an action with no alias is still reachable
+    // by name (e.g. `POST /api/permissions/create`), so every mutating action MUST
+    // also be `types`-gated. Mutations go through the explicit, ADMIN-typed
+    // `findOrCreate` / `modifyAccessForGroup` actions; internal broker calls (e.g.
+    // from findUsersByAccess) bypass the gateway `authorize()` and keep working.
     create: {
       rest: null,
+      types: [EndpointType.SUPER_ADMIN],
     },
     update: {
       rest: null,
@@ -241,8 +244,12 @@ export default class PermissionsService extends moleculer.Service {
     // PII guard: this endpoint is API-key only (no user). Scope the lookup to the
     // calling app so one app's key cannot enumerate users (email/name) across the
     // whole BIIP estate. ADMIN-type apps legitimately span apps, so they keep the
-    // cross-app view.
-    if (app && app.type !== AppType.ADMIN) {
+    // cross-app view. Fail CLOSED if there is no app context (should be
+    // unreachable — verifyApiKey 401s first — but never return unscoped PII).
+    if (!app) {
+      throwUnauthorizedError('No application context.');
+    }
+    if (app.type !== AppType.ADMIN) {
       query.app = app.id;
     }
 

--- a/services/permissions.service.ts
+++ b/services/permissions.service.ts
@@ -133,8 +133,31 @@ interface PermissionType {
 
   actions: {
     ...DISABLE_REST_ACTIONS,
+    // The @moleculer/database mixin exposes get/list/create/update/remove over
+    // REST by default. Permissions are the authorization source of truth, so the
+    // raw CRUD surface must NOT be reachable by ordinary users: an authenticated
+    // USER could otherwise `PATCH /api/permissions/:id {accesses:["*"]}` to grant
+    // themselves anything (privilege escalation), or enumerate every permission
+    // via `GET /api/permissions`. Mutations go through the explicit, ADMIN-typed
+    // `findOrCreate` / `modifyAccessForGroup` actions instead; internal broker
+    // calls (e.g. from findUsersByAccess) keep working because `rest: null` only
+    // drops the HTTP alias, not the action.
     create: {
       rest: null,
+    },
+    update: {
+      rest: null,
+      types: [EndpointType.SUPER_ADMIN],
+    },
+    remove: {
+      rest: null,
+      types: [EndpointType.SUPER_ADMIN],
+    },
+    get: {
+      types: [EndpointType.ADMIN, EndpointType.SUPER_ADMIN],
+    },
+    list: {
+      types: [EndpointType.ADMIN, EndpointType.SUPER_ADMIN],
     },
   },
 
@@ -199,20 +222,33 @@ export default class PermissionsService extends moleculer.Service {
       },
     },
   })
-  async findUsersByAccess(ctx: Context<{ access: string; municipality: number }>) {
+  async findUsersByAccess(
+    ctx: Context<{ access: string; municipality: number }, AppAuthMeta>,
+  ) {
     const { access, municipality } = ctx.params;
+    const app = ctx.meta.app;
+
+    const query: GenericObject = {
+      accesses: {
+        $exists: true,
+      },
+      $raw: {
+        condition: `"accesses" @> ?::jsonb`,
+        bindings: [JSON.stringify([access])],
+      },
+    };
+
+    // PII guard: this endpoint is API-key only (no user). Scope the lookup to the
+    // calling app so one app's key cannot enumerate users (email/name) across the
+    // whole BIIP estate. ADMIN-type apps legitimately span apps, so they keep the
+    // cross-app view.
+    if (app && app.type !== AppType.ADMIN) {
+      query.app = app.id;
+    }
 
     const parentCtx: any = {};
     const permissions: Array<Permission> = await ctx.call('permissions.find', {
-      query: {
-        accesses: {
-          $exists: true,
-        },
-        $raw: {
-          condition: `"accesses" @> ?::jsonb`,
-          bindings: [JSON.stringify([access])],
-        },
-      },
+      query,
     });
 
     let userList: Array<any> = await Promise.all(

--- a/services/userGroups.service.ts
+++ b/services/userGroups.service.ts
@@ -330,7 +330,14 @@ export default class UserGroupsService extends moleculer.Service {
       path: '/unassign',
       basePath: '/users/:user/groups/:group',
     },
-    types: [EndpointType.ADMIN, EndpointType.SUPER_ADMIN],
+    // AuthZ by group-admin membership, not global UserType. External company
+    // managers land in auth as UserType.USER (eVartai users default to USER), so
+    // a blunt [ADMIN, SUPER_ADMIN] gate 401'd them: tenant apps could ADD a member
+    // (via users.invite, which self-authorizes and assigns over an internal broker
+    // call) but never REMOVE one — the app deleted its local row while the auth
+    // membership lingered (desync). Mirror the usersEvartai.invite check. Dropping
+    // the type gate is safe here: `unassign` has NO internal broker callers (only
+    // the tenant apps' HTTP unassignFromGroup), so no login/invite flow is touched.
     params: {
       user: {
         type: 'number',
@@ -342,8 +349,25 @@ export default class UserGroupsService extends moleculer.Service {
       },
     },
   })
-  async unassign(ctx: Context<{ user: number; group: number }>) {
+  async unassign(ctx: Context<{ user: number; group: number }, AppAuthMeta & UserAuthMeta>) {
     const { user, group } = ctx.params;
+    const { meta } = ctx;
+
+    // getVisibleGroupsIds({edit:true}) returns, scoped to the calling app: every
+    // app group for SUPER_ADMIN, app companies for ADMIN, the groups the caller is
+    // group-ADMIN of for a USER, and all app groups for an app-key-only call.
+    const editableGroupIds: any[] = await ctx.call(
+      'permissions.getVisibleGroupsIds',
+      { edit: true },
+      { meta },
+    );
+    if (!editableGroupIds?.map(Number).includes(Number(group))) {
+      throw new moleculer.Errors.MoleculerClientError(
+        `Not authorized to modify membership of group '${group}'.`,
+        403,
+        'AUTH_UNAUTHORIZED_GROUP',
+      );
+    }
 
     const userGroup: UserGroup = await ctx.call('userGroups.findOne', {
       query: { user, group },

--- a/services/users.service.ts
+++ b/services/users.service.ts
@@ -226,14 +226,22 @@ export interface User extends BaseModelInterface {
 
   actions: {
     ...DISABLE_REST_ACTIONS,
+    // Under the gateway's `mappingPolicy: 'all'`, `rest: null` is NOT enough —
+    // these raw CRUD actions stay reachable by name (e.g. `POST /api/users/create`)
+    // and so must be type-gated. The real HTTP user lifecycle goes through
+    // usersLocal.invite (create) / usersLocal.update (PATCH /:id) / users.removeUser
+    // (DELETE /:id); internal broker callers bypass the gateway `authorize()`.
     create: {
       rest: null,
+      types: [EndpointType.SUPER_ADMIN],
     },
     update: {
       rest: null,
+      types: [EndpointType.SUPER_ADMIN],
     },
     remove: {
       rest: null,
+      types: [EndpointType.SUPER_ADMIN],
     },
   },
 
@@ -261,6 +269,9 @@ export default class UsersService extends moleculer.Service {
   // cacheCleanEvents). Caller must have already validated the user exists;
   // adapter.updateById skips default scopes (notDeleted) and field validation.
   @Action({
+    // Internal-only (login flows). Type-gate so the gateway's mappingPolicy:'all'
+    // can't let an arbitrary user touch another user's lastLoggedInAt.
+    types: [EndpointType.SUPER_ADMIN],
     params: {
       id: 'number|convert',
     },
@@ -332,6 +343,10 @@ export default class UsersService extends moleculer.Service {
   }
 
   @Action({
+    // Grants/revokes a user's app access (privilege change). No HTTP caller; all
+    // real toggling is internal (usersLocal/usersEvartai). SUPER_ADMIN-gate so the
+    // gateway's mappingPolicy:'all' can't expose it to any logged-in user.
+    types: [EndpointType.SUPER_ADMIN],
     params: {
       id: 'number|convert',
       appId: 'number|convert',
@@ -361,6 +376,8 @@ export default class UsersService extends moleculer.Service {
   }
 
   @Action({
+    // Bulk app-access mutation; same exposure as toggleApp. Internal-only.
+    types: [EndpointType.SUPER_ADMIN],
     params: {
       id: {
         type: 'number',
@@ -392,6 +409,10 @@ export default class UsersService extends moleculer.Service {
   }
 
   @Action({
+    // Group membership == permission grant. No HTTP caller (the admin "assign to
+    // group" flow uses userGroups.assign, which is ADMIN-gated separately).
+    // Internal-only; SUPER_ADMIN-gate against the mappingPolicy:'all' bypass.
+    types: [EndpointType.SUPER_ADMIN],
     params: {
       id: {
         type: 'number',

--- a/services/usersEvartai.service.ts
+++ b/services/usersEvartai.service.ts
@@ -224,8 +224,10 @@ export default class UsersEvartaiService extends moleculer.Service {
   async sign(ctx: Context<{ host: string }, AppAuthMeta>) {
     // `host` is where eVartai sends the user back (with the auth ticket in the
     // URL). An unvalidated host means the ticket can be delivered to an attacker
-    // domain → account takeover. Restrict to the registered-app redirect
-    // allow-list (same guard `redirectEvartai` uses for the final 302).
+    // domain → account takeover. Restrict to the registered-app allow-list at
+    // ORIGIN level (protocol+host) via auth.isRedirectAllowed — origin
+    // confinement closes off-domain delivery while tolerating app URLs that carry
+    // a path. (redirectEvartai keeps the stricter path-aware check on its 302.)
     const allowed: boolean = await ctx.call('auth.isRedirectAllowed', {
       target: ctx.params.host,
     });

--- a/services/usersEvartai.service.ts
+++ b/services/usersEvartai.service.ts
@@ -11,6 +11,7 @@ import {
   COMMON_DEFAULT_SCOPES,
   COMMON_FIELDS,
   COMMON_SCOPES,
+  EndpointType,
   FieldHookCallback,
   throwBadRequestError,
   throwNotFoundError,
@@ -525,6 +526,13 @@ export default class UsersEvartaiService extends moleculer.Service {
   }
 
   @Action({
+    // Internal-only: the real HTTP delete goes through `users.removeUser`
+    // (validateIfAuthorized hook). This action is reachable by name under the
+    // gateway's `mappingPolicy: 'all'` (`POST /api/usersEvartai/removeUser`), and
+    // it has no before-hook, so without a type gate any authenticated USER could
+    // revoke an arbitrary user's app access. SUPER_ADMIN-gate it; internal broker
+    // callers bypass authorize().
+    types: [EndpointType.SUPER_ADMIN],
     params: {
       id: {
         type: 'number',

--- a/services/usersEvartai.service.ts
+++ b/services/usersEvartai.service.ts
@@ -174,12 +174,25 @@ export default class UsersEvartaiService extends moleculer.Service {
       throwIfNotExist: true,
     });
 
-    // default assignment to group
+    // default assignment to group — only honour a defaultGroupId that actually
+    // belongs to the app being logged into. Otherwise the caller could self-assign
+    // into ANY group by id (privilege escalation). An invalid id is ignored (not
+    // fatal) so a bad param can't block an otherwise valid login.
     if (defaultGroupId) {
-      await ctx.call('userGroups.assign', {
-        user: user.id,
+      const allowedAppIds: any[] = await ctx.call('inheritedGroupApps.getAppsByGroup', {
         group: defaultGroupId,
       });
+      if (allowedAppIds?.map(Number).includes(Number(appId))) {
+        await ctx.call('userGroups.assign', {
+          user: user.id,
+          group: defaultGroupId,
+        });
+      } else {
+        this.logger.warn('Ignoring defaultGroupId that does not belong to the app', {
+          defaultGroupId,
+          appId,
+        });
+      }
     }
 
     // update on every login via evartai
@@ -208,12 +221,24 @@ export default class UsersEvartaiService extends moleculer.Service {
       host: 'string',
     },
   })
-  async sign(ctx: Context<{ host: string }>) {
+  async sign(ctx: Context<{ host: string }, AppAuthMeta>) {
+    // `host` is where eVartai sends the user back (with the auth ticket in the
+    // URL). An unvalidated host means the ticket can be delivered to an attacker
+    // domain → account takeover. Restrict to the registered-app redirect
+    // allow-list (same guard `redirectEvartai` uses for the final 302).
+    const allowed: boolean = await ctx.call('auth.isRedirectAllowed', {
+      target: ctx.params.host,
+    });
+    if (!allowed) {
+      return throwBadRequestError('Invalid host');
+    }
+
     try {
-      return fetch(`${process.env.EVARTAI_HOST}/auth/sign`, {
+      const response = await fetch(`${process.env.EVARTAI_HOST}/auth/sign`, {
         method: 'POST',
         body: JSON.stringify({ host: ctx.params.host }),
-      }).then((r) => r.json());
+      });
+      return await response.json();
     } catch (err) {
       return throwBadRequestError('Cannot sign ticket', err);
     }
@@ -383,6 +408,24 @@ export default class UsersEvartaiService extends moleculer.Service {
 
         if (!company?.id) {
           throwNotFoundError('Company not found');
+        }
+
+        // AuthZ: only assign a person into a company the caller may administer.
+        // getVisibleGroupsIds({edit:true}) returns, scoped to the calling app:
+        // every app group for SUPER_ADMIN, otherwise the groups the caller is
+        // ADMIN of. Without this any authenticated USER could add an arbitrary
+        // person into any company (cross-company privilege grant).
+        const editableGroupIds: any[] = await ctx.call(
+          'permissions.getVisibleGroupsIds',
+          { edit: true },
+          { meta },
+        );
+        if (!editableGroupIds?.map(Number).includes(Number(companyId))) {
+          throw new moleculer.Errors.MoleculerClientError(
+            `Not authorized to assign users to company '${companyId}'.`,
+            403,
+            'AUTH_UNAUTHORIZED_COMPANY',
+          );
         }
 
         const assignedToCompany = await this.assignUserToCompanyIfCompanyExists(
@@ -647,7 +690,7 @@ export default class UsersEvartaiService extends moleculer.Service {
     let userData: any;
 
     try {
-      const url = `${process.env.EVARTAI_HOST}/auth/data?ticket=${ticket}`;
+      const url = `${process.env.EVARTAI_HOST}/auth/data?ticket=${encodeURIComponent(ticket)}`;
       userData = await fetch(url).then((r) => r.json());
     } catch (err) {
       throwBadRequestError('Cannot parse ticket', err);

--- a/services/usersLocal.service.ts
+++ b/services/usersLocal.service.ts
@@ -530,6 +530,14 @@ export default class UsersLocalService extends moleculer.Service {
   }
 
   @Action({
+    // Internal-only: the real HTTP delete goes through `users.removeUser`
+    // (validateIfAuthorized hook), which delegates here via an internal call.
+    // This action is reachable by name under the gateway's `mappingPolicy: 'all'`
+    // (`POST /api/usersLocal/removeUser`) and has no before-hook, so without a
+    // type gate any authenticated USER could delete an arbitrary user (the inner
+    // `users.remove` call bypasses its own gateway gate). SUPER_ADMIN-gate it;
+    // internal broker callers bypass authorize().
+    types: [EndpointType.SUPER_ADMIN],
     params: {
       id: {
         type: 'number',

--- a/services/usersLocal.service.ts
+++ b/services/usersLocal.service.ts
@@ -566,12 +566,15 @@ export default class UsersLocalService extends moleculer.Service {
 
   @Method
   encryptPassword(password: string) {
-    return bcrypt.hashSync(password, 10);
+    // cost 12: stronger work factor for a central gov IdP. Existing cost-10
+    // hashes still verify (bcrypt encodes the cost in the hash).
+    return bcrypt.hashSync(password, 12);
   }
 
   @Method
-  isPasswordValid(hashedPassword: string, password: string) {
-    return bcrypt.compare(hashedPassword, password);
+  isPasswordValid(plainPassword: string, hashedPassword: string) {
+    // bcrypt.compare(data, encrypted) — plaintext first, stored hash second.
+    return bcrypt.compare(plainPassword, hashedPassword);
   }
 
   @Method

--- a/test/integration/api/security.spec.ts
+++ b/test/integration/api/security.spec.ts
@@ -223,6 +223,33 @@ describe('Security hardening', () => {
           expect([401, 403]).toContain(res.status);
         });
     });
+
+    // The user-deletion analog of the groups.removeGroup gate above. The real
+    // HTTP delete is `users.removeUser` (validateIfAuthorized hook); these inner
+    // sub-service actions are internal-only but reachable by name via the same
+    // mappingPolicy:'all' direct-mapping, with no before-hook. Use adminToken (a
+    // real ADMIN) — they are SUPER_ADMIN-gated, so blocking an ADMIN proves the
+    // gate. A non-existent id keeps the assertion non-destructive: gate present →
+    // 401/403; gate removed → the action would run and 404 (still fails here).
+    it('an ADMIN cannot delete a user via POST /api/usersLocal/removeUser', () => {
+      return request(apiService.server)
+        .post('/api/usersLocal/removeUser')
+        .set(apiHelper.getHeaders(apiHelper.adminToken, apiHelper.appFishing.apiKey))
+        .send({ id: 999999 })
+        .expect((res: any) => {
+          expect([401, 403]).toContain(res.status);
+        });
+    });
+
+    it('an ADMIN cannot revoke app access via POST /api/usersEvartai/removeUser', () => {
+      return request(apiService.server)
+        .post('/api/usersEvartai/removeUser')
+        .set(apiHelper.getHeaders(apiHelper.adminToken, apiHelper.appFishing.apiKey))
+        .send({ id: 999999 })
+        .expect((res: any) => {
+          expect([401, 403]).toContain(res.status);
+        });
+    });
   });
 
   // eVartai `sign` must only accept a host whose ORIGIN is a registered app URL,

--- a/test/integration/api/security.spec.ts
+++ b/test/integration/api/security.spec.ts
@@ -1,0 +1,156 @@
+'use strict';
+import { ServiceBroker } from 'moleculer';
+import { ApiHelper, serviceBrokerConfig } from '../../helpers/api';
+import { expect, describe, beforeAll, afterAll, it } from '@jest/globals';
+
+const request = require('supertest');
+
+const broker = new ServiceBroker(serviceBrokerConfig);
+
+const apiHelper = new ApiHelper(broker);
+const apiService = apiHelper.initializeServices();
+
+const initialize = async (broker: any) => {
+  await broker.start();
+  await apiHelper.setup();
+
+  return true;
+};
+
+// Regression tests for the security hardening on this branch. Each block maps to
+// a specific finding so a future change that re-opens the hole fails loudly.
+describe('Security hardening', () => {
+  beforeAll(() => initialize(broker));
+  afterAll(() => broker.stop());
+
+  // P0-1: the raw permissions CRUD surface must not be reachable by ordinary
+  // users (privilege escalation / enumeration).
+  describe('permissions CRUD is locked down', () => {
+    it('regular user cannot PATCH a permission', () => {
+      return request(apiService.server)
+        .patch('/api/permissions/1')
+        .set(apiHelper.getHeaders(apiHelper.fisherToken, apiHelper.appFishing.apiKey))
+        .send({ accesses: ['*'], role: 'ADMIN' })
+        .expect((res: any) => {
+          expect([401, 403, 404]).toContain(res.status);
+        });
+    });
+
+    it('regular user cannot DELETE a permission', () => {
+      return request(apiService.server)
+        .delete('/api/permissions/1')
+        .set(apiHelper.getHeaders(apiHelper.fisherToken, apiHelper.appFishing.apiKey))
+        .expect((res: any) => {
+          expect([401, 403, 404]).toContain(res.status);
+        });
+    });
+
+    it('regular user cannot list permissions', () => {
+      return request(apiService.server)
+        .get('/api/permissions')
+        .set(apiHelper.getHeaders(apiHelper.fisherToken, apiHelper.appFishing.apiKey))
+        .expect((res: any) => {
+          expect([401, 403]).toContain(res.status);
+        });
+    });
+
+    it('regular user cannot get a permission by id', () => {
+      return request(apiService.server)
+        .get('/api/permissions/1')
+        .set(apiHelper.getHeaders(apiHelper.fisherToken, apiHelper.appFishing.apiKey))
+        .expect((res: any) => {
+          expect([401, 403, 404]).toContain(res.status);
+        });
+    });
+  });
+
+  // P1-9: full cache flush is a DoS lever. The gateway's own action is not
+  // auto-aliased under /api in this config (so it currently 404s), but the
+  // action is also SUPER_ADMIN-typed now — assert a regular user can never get a
+  // success response (guards against it being re-exposed as PUBLIC).
+  describe('cache clean is not callable by a regular user', () => {
+    it('regular user does not get a success response', () => {
+      return request(apiService.server)
+        .post('/api/cache/clean')
+        .set(apiHelper.getHeaders(apiHelper.fisherToken, apiHelper.appFishing.apiKey))
+        .expect((res: any) => {
+          expect(res.status).toBeGreaterThanOrEqual(400);
+        });
+    });
+  });
+
+  // P1-6: assigning a person into a company requires admin rights on that
+  // company. A group member who is not its admin must be refused.
+  describe('cross-company invite guard', () => {
+    it('company admin can assign a person to their company', () => {
+      return request(apiService.server)
+        .post('/api/users/invite')
+        .set(apiHelper.getHeaders(apiHelper.fisherToken, apiHelper.appFishing.apiKey))
+        .send({
+          personalCode: '91234567895',
+          companyId: apiHelper.groupFishersCompany.id,
+          throwErrors: false,
+        })
+        .expect(200);
+    });
+
+    it('non-admin group member cannot assign a person to the company', () => {
+      return request(apiService.server)
+        .post('/api/users/invite')
+        .set(apiHelper.getHeaders(apiHelper.fisherUserToken, apiHelper.appFishing.apiKey))
+        .send({
+          personalCode: '91234567892',
+          companyId: apiHelper.groupFishersCompany.id,
+          throwErrors: false,
+        })
+        .expect((res: any) => {
+          expect([401, 403]).toContain(res.status);
+          expect(res.body.type).toEqual('AUTH_UNAUTHORIZED_COMPANY');
+        });
+    });
+
+    it('company admin cannot assign into a company of another app', () => {
+      return request(apiService.server)
+        .post('/api/users/invite')
+        .set(apiHelper.getHeaders(apiHelper.fisherToken, apiHelper.appFishing.apiKey))
+        .send({
+          personalCode: '91234567893',
+          companyId: apiHelper.groupHuntersCompany.id,
+          throwErrors: false,
+        })
+        .expect((res: any) => {
+          expect([401, 403]).toContain(res.status);
+          expect(res.body.type).toEqual('AUTH_UNAUTHORIZED_COMPANY');
+        });
+    });
+  });
+
+  // P1-11: password login is throttled after repeated failures.
+  describe('login brute-force throttle', () => {
+    beforeAll(() => {
+      process.env.ENABLE_LOGIN_RATE_LIMIT = 'true';
+    });
+    afterAll(async () => {
+      delete process.env.ENABLE_LOGIN_RATE_LIMIT;
+      await broker.cacher?.del?.('auth.loginAttempts:bruteforce.target@am.lt');
+    });
+
+    it('blocks after too many failed attempts', async () => {
+      const email = 'bruteforce.target@am.lt';
+      const attempt = () =>
+        request(apiService.server)
+          .post('/auth/login')
+          .set(apiHelper.getHeaders(null, apiHelper.appFishing.apiKey))
+          .send({ email, password: 'WrongPassword1@' });
+
+      for (let i = 0; i < 10; i++) {
+        await attempt().expect(400);
+      }
+
+      return attempt().expect((res: any) => {
+        expect(res.status).toEqual(429);
+        expect(res.body.type).toEqual('TOO_MANY_ATTEMPTS');
+      });
+    });
+  });
+});

--- a/test/integration/api/security.spec.ts
+++ b/test/integration/api/security.spec.ts
@@ -280,4 +280,56 @@ describe('Security hardening', () => {
         .expect(200);
     });
   });
+
+  // Removing a company member must authorize by GROUP-admin membership, not global
+  // UserType. External company managers are UserType.USER (eVartai default), so the
+  // old [ADMIN, SUPER_ADMIN] gate on userGroups.unassign 401'd them — tenant apps
+  // could invite a member but never remove one (local row deleted, auth membership
+  // left dangling). This mirrors the usersEvartai.invite authz.
+  describe('group-admin can unassign a member (invite parity)', () => {
+    const unassign = (userId: number, groupId: number, token: string) =>
+      request(apiService.server)
+        .post(`/api/users/${userId}/groups/${groupId}/unassign`)
+        .set(apiHelper.getHeaders(token, apiHelper.appFishing.apiKey));
+
+    it('a group-ADMIN (UserType.USER) can unassign a member of their company', async () => {
+      await unassign(apiHelper.fisherUser.id, apiHelper.groupFishersCompany.id, apiHelper.fisherToken)
+        .expect(200)
+        .expect((res: any) => expect(res.body.success).toEqual(true));
+
+      const membership = await broker.call('userGroups.findOne', {
+        query: { user: apiHelper.fisherUser.id, group: apiHelper.groupFishersCompany.id },
+      });
+      expect(membership).toBeFalsy();
+
+      // restore fixture state so ordering can't couple to this suite
+      await broker.call('userGroups.create', {
+        user: apiHelper.fisherUser.id,
+        group: apiHelper.groupFishersCompany.id,
+        role: 'USER',
+      });
+    });
+
+    it('a non-admin group member cannot unassign', () => {
+      return unassign(
+        apiHelper.fisher.id,
+        apiHelper.groupFishersCompany.id,
+        apiHelper.fisherUserToken,
+      ).expect((res: any) => {
+        expect([401, 403]).toContain(res.status);
+        expect(res.body.type).toEqual('AUTH_UNAUTHORIZED_GROUP');
+      });
+    });
+
+    it('a group-ADMIN cannot unassign from a company of another app', () => {
+      return unassign(
+        apiHelper.fisherUser.id,
+        apiHelper.groupHuntersCompany.id,
+        apiHelper.fisherToken,
+      ).expect((res: any) => {
+        expect([401, 403]).toContain(res.status);
+        expect(res.body.type).toEqual('AUTH_UNAUTHORIZED_GROUP');
+      });
+    });
+  });
 });

--- a/test/integration/api/security.spec.ts
+++ b/test/integration/api/security.spec.ts
@@ -1,7 +1,7 @@
 'use strict';
 import { ServiceBroker } from 'moleculer';
 import { ApiHelper, serviceBrokerConfig } from '../../helpers/api';
-import { expect, describe, beforeAll, afterAll, it } from '@jest/globals';
+import { expect, describe, beforeAll, afterAll, it, jest } from '@jest/globals';
 
 const request = require('supertest');
 
@@ -133,6 +133,7 @@ describe('Security hardening', () => {
     afterAll(async () => {
       delete process.env.ENABLE_LOGIN_RATE_LIMIT;
       await broker.cacher?.del?.('auth.loginAttempts:bruteforce.target@am.lt');
+      await broker.cacher?.del?.('auth.loginAttempts:user.fisher@am.lt');
     });
 
     it('blocks after too many failed attempts', async () => {
@@ -151,6 +152,105 @@ describe('Security hardening', () => {
         expect(res.status).toEqual(429);
         expect(res.body.type).toEqual('TOO_MANY_ATTEMPTS');
       });
+    });
+
+    it('clears the failed-attempt counter on a successful login', async () => {
+      const email = apiHelper.emailFisher;
+      const key = `auth.loginAttempts:${email.toLowerCase()}`;
+      const fail = () =>
+        request(apiService.server)
+          .post('/auth/login')
+          .set(apiHelper.getHeaders(null, apiHelper.appFishing.apiKey))
+          .send({ email, password: 'WrongPassword1@' });
+
+      for (let i = 0; i < 3; i++) await fail().expect(400);
+      expect((await broker.cacher?.get(key))?.count).toBeGreaterThan(0);
+
+      // A successful login must reset the counter so a legit user is never locked
+      // out by their own earlier typos.
+      await request(apiService.server)
+        .post('/auth/login')
+        .set(apiHelper.getHeaders(null, apiHelper.appFishing.apiKey))
+        .send({ email, password: apiHelper.goodPassword })
+        .expect(200);
+
+      expect(await broker.cacher?.get(key)).toBeFalsy();
+    });
+  });
+
+  // mappingPolicy:'all' on the /api route means an action with no REST alias is
+  // still reachable by name (POST /api/<service>/<action>). rest:null does NOT
+  // protect it — only a `types` gate does. These assert the raw mutating actions
+  // reject a non-privileged caller via that direct-mapping path.
+  describe('raw action surface is type-gated (mappingPolicy bypass)', () => {
+    // Use adminToken (a real UserType.ADMIN) — these actions are SUPER_ADMIN-only,
+    // so blocking an ADMIN proves the gate, not just the absence of privilege.
+    it('an ADMIN cannot self-grant via POST /api/permissions/create', () => {
+      return request(apiService.server)
+        .post('/api/permissions/create')
+        .set(apiHelper.getHeaders(apiHelper.adminToken, apiHelper.appFishing.apiKey))
+        .send({ group: apiHelper.groupFishersCompany.id, accesses: ['*'], role: 'ADMIN' })
+        .expect((res: any) => {
+          expect([401, 403]).toContain(res.status);
+        });
+    });
+
+    it('an ADMIN cannot create a user via POST /api/users/create', () => {
+      return request(apiService.server)
+        .post('/api/users/create')
+        .set(apiHelper.getHeaders(apiHelper.adminToken, apiHelper.appFishing.apiKey))
+        .send({ firstName: 'X', lastName: 'Y', email: 'bypass.create@am.lt' })
+        .expect((res: any) => {
+          expect([401, 403]).toContain(res.status);
+        });
+    });
+
+    it('an ADMIN cannot grant group membership via POST /api/users/assignGroups', () => {
+      return request(apiService.server)
+        .post('/api/users/assignGroups')
+        .set(apiHelper.getHeaders(apiHelper.adminToken, apiHelper.appFishing.apiKey))
+        .send({ id: 1, groups: [{ id: apiHelper.groupFishersCompany.id, role: 'ADMIN' }] })
+        .expect((res: any) => {
+          expect([401, 403]).toContain(res.status);
+        });
+    });
+
+    it('a regular user cannot delete a group via DELETE /api/groups/:id', () => {
+      return request(apiService.server)
+        .delete('/api/groups/999999')
+        .set(apiHelper.getHeaders(apiHelper.fisherUserToken, apiHelper.appFishing.apiKey))
+        .expect((res: any) => {
+          expect([401, 403]).toContain(res.status);
+        });
+    });
+  });
+
+  // eVartai `sign` must only accept a host whose ORIGIN is a registered app URL,
+  // so an attacker host can't receive the auth ticket (account takeover).
+  describe('evartai sign host validation', () => {
+    // Restore after each test so the global.fetch stub from the accept case can
+    // never leak into a later suite.
+    afterEach(() => jest.restoreAllMocks());
+
+    it('rejects a host that is not a registered app origin', () => {
+      return request(apiService.server)
+        .post('/auth/evartai/sign')
+        .set(apiHelper.getHeaders(null, apiHelper.appFishing.apiKey))
+        .send({ host: 'https://attacker.example.com' })
+        .expect((res: any) => {
+          expect(res.status).toEqual(400);
+          expect(res.body.message).toEqual('Invalid host');
+        });
+    });
+
+    it('accepts a registered app origin', () => {
+      apiHelper.interceptFetch({ ticket: 'mock-ticket', url: 'https://evartai.example/auth' });
+      const host = new URL(apiHelper.appFishing.url).origin;
+      return request(apiService.server)
+        .post('/auth/evartai/sign')
+        .set(apiHelper.getHeaders(null, apiHelper.appFishing.apiKey))
+        .send({ host })
+        .expect(200);
     });
   });
 });

--- a/utils/tokens.ts
+++ b/utils/tokens.ts
@@ -4,18 +4,26 @@ import { User } from '../services/users.service';
 
 export function verifyToken(token: string) {
   return new Promise<User | App | undefined>((resolve, reject) => {
-    jwt.verify(token, process.env.JWT_SECRET, (err: VerifyErrors | null, decoded?: any) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(decoded);
-      }
-    });
+    // Pin the algorithm so a token can't be accepted under an unexpected alg
+    // (algorithm-confusion hardening).
+    jwt.verify(
+      token,
+      process.env.JWT_SECRET,
+      { algorithms: ['HS256'] },
+      (err: VerifyErrors | null, decoded?: any) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(decoded);
+        }
+      },
+    );
   });
 }
 export async function generateToken(payload: any, expiresIn: number = 60 * 60 * 24) {
   // default expires is 24 hours
   return jwt.sign(payload, process.env.JWT_SECRET, {
     expiresIn,
+    algorithm: 'HS256',
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #47 (which merged the first round of security fixes but left the **permissions CRUD privilege-escalation open** and a few related gaps). This PR closes the remaining authorization/PII/abuse holes found in a deep audit of the auth service. All changes are server-side and chosen to **not break existing API clients** (no new env vars, no DB migration).

Scope agreed with the maintainer: **P0 + safe P1/P2 only**. Dependency CVE upgrades and the larger infra-dependent items (separate JWT/API-key secrets, token revocation, reCAPTCHA enforcement) are tracked as follow-ups (see below).

## Fixes

| Sev | Issue | Fix |
|-----|-------|-----|
| **P0** | Any authenticated USER could `PATCH /api/permissions/:id {accesses:["*"]}` → self-escalate to ADMIN, or enumerate all permissions via `GET /api/permissions`. Root cause: `@moleculer/database` REST-exposes get/list/create/update/remove by default; `DISABLE_REST_ACTIONS` only covered count/find/replace, and the gateway treats empty `types` as allow-any-authenticated. | Lock update/remove (`rest:null` + SUPER_ADMIN), ADMIN-gate get/list on `permissions`. Internal broker calls unaffected. |
| **P0** | `permissions.findUsersByAccess` (API-key only) returned users (email/name) across **all** apps. | Scope the lookup to the calling app (ADMIN-type apps keep cross-app). |
| **P1** | `POST /cache/clean` was `auth: PUBLIC` → full Redis flush = service-wide brownout. | SUPER_ADMIN only. |
| **P1** | `usersEvartai.sign` forwarded an unvalidated `host`; the eVartai ticket is returned to that host → ticket/login could leak off-domain (account takeover). | Validate `host` against the registered-app redirect allow-list; also `encodeURIComponent` the ticket in `getUserByTicket` (query-injection) and `await` the fetch. |
| **P1** | eVartai `defaultGroupId` let a user self-assign into **any** group by id. | Only honour a defaultGroupId that belongs to the app; ignore otherwise (login still succeeds). |
| **P1** | `invite` (`personalCode`+`companyId`) assigned a person to a company without checking the caller administers it. | Gate on `permissions.getVisibleGroupsIds({edit})` — company admin / super admin only. |
| **P1** | Counterpart to the invite fix: `userGroups.unassign` (`POST /api/users/:id/groups/:groupId/unassign`) was gated `[ADMIN, SUPER_ADMIN]`, but external company managers are `UserType.USER` (eVartai users default to USER) with only a group-ADMIN role. So tenant apps (uetk, rusys, medziokle, gyvunai, zuvinimas, zvejyba) could *add* a member (`users.invite` self-authorizes + assigns over an internal broker call) but every *remove* 401'd — the app deleted its local row first, leaving the auth group membership dangling (**desync**, reproduced live in uetk & rusys). | Authorize on group-admin membership via `getVisibleGroupsIds({edit})` — mirrors the invite fix; drops the type gate. Safe: `unassign` has **no** internal broker callers, so login/invite are untouched. _Deferred: `assign` keeps the `[ADMIN, SUPER_ADMIN]` gate — it has internal login/invite callers, so it needs gateway-only scoping (separate change)._ |
| **P1** | `jwt.verify/sign` didn't pin the algorithm. | Pin to HS256. |
| **P1** | No brute-force protection on `/auth/login`. | Per-email failed-attempt throttle (Redis, rolling window, clears on success; configurable via `LOGIN_MAX_ATTEMPTS`/`LOGIN_ATTEMPTS_WINDOW`). |
| **P2** | `logout` logged the raw bearer token (`console.log`) and had a dead `if (!valid)` guard. `rejectAuth` logged full params+meta (incl. authToken) on every auth failure. | Remove token log, guard on `valid?.id`, redact auth-failure logs to userId/appId only. |
| **P2** | bcrypt cost 10 for a central gov IdP. | Raise to 12 (existing hashes still verify). Clarify `isPasswordValid` param naming. |

## Verification

- `tsc --noEmit` ✅ · `eslint` (changed files) ✅ · Semgrep `p/security-audit`+`p/typescript` → 0 findings ✅
- **Full test suite: 21 suites / 264 tests green**, incl. `test/integration/api/security.spec.ts` covering the permissions lockdown, cache-clean rejection, cross-company guard, login throttle, and the group-admin unassign parity (group-ADMIN → 200; non-admin member → 403; other-app company → 403). No regressions in existing permissions/evartai/invite/auth specs.
- The `unassign` authz change was independently re-reviewed by an adversarial security pass: no blocking findings, confirmed at parity with the `invite` gate (app-scoped, fail-closed, tightens the blast radius for global admins).

## Deliberately deferred (follow-ups)

- **Dependency CVEs** (62 reported, incl. form-data 9.4, axios, lodash, tar) — separate PR with its own build/lockfile verification (Yarn).
- Separate secrets for user-JWT / app-API-key / HMAC links; app API-key revocation on rotation; token-version revocation on password change/logout (needs a migration); reCAPTCHA enforcement + gateway rate-limit (needs FE coordination / tuning). These change deploy/runtime behaviour and warrant their own PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
