### PR TITLE
feat(auth): force 90-day password rotation for admins

### DIFF
--- a/database/migrations/20260622120000_addLastPasswordChangeAtToUsersLocal.js
+++ b/database/migrations/20260622120000_addLastPasswordChangeAtToUsersLocal.js
@@ -1,0 +1,30 @@
+/**
+ * Periodic password rotation for admins: track when each local password was
+ * last set. Existing rows are backfilled to `createdAt` so current admins are
+ * treated as expired and forced to rotate on their next login (rows with no
+ * `createdAt` stay NULL, which the app also treats as "must change").
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .alterTable('usersLocal', (table) => {
+      table.timestamp('lastPasswordChangeAt');
+    })
+    .then(() =>
+      knex('usersLocal')
+        .whereNull('lastPasswordChangeAt')
+        .update({ lastPasswordChangeAt: knex.ref('createdAt') }),
+    );
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('usersLocal', (table) => {
+    table.dropColumn('lastPasswordChangeAt');
+  });
+};

--- a/services/api.service.ts
+++ b/services/api.service.ts
@@ -332,6 +332,21 @@ export default class ApiService extends moleculer.Service {
       );
     }
 
+    // Lock an admin whose password is expired to the password-change flow:
+    // every action is rejected except reading their own profile, logging out,
+    // and the password-change endpoint itself. Fail closed — anything not on
+    // the allow-list is denied while the flag is set.
+    if (user.passwordMustChange && !this.isAllowedWhilePasswordExpired(req.$action?.name)) {
+      return this.rejectAuth(
+        ctx,
+        new Errors.MoleculerClientError(
+          'Password change required.',
+          403,
+          'PASSWORD_CHANGE_REQUIRED',
+        ),
+      );
+    }
+
     const aTypes = Array.isArray(req.$action.types) ? req.$action.types : [req.$action.types];
     const oTypes = Array.isArray(req.$route.opts.types)
       ? req.$route.opts.types
@@ -349,6 +364,14 @@ export default class ApiService extends moleculer.Service {
     }
 
     return Promise.resolve(ctx);
+  }
+
+  // Actions an admin may still call while their password is expired: read own
+  // profile, log out, and change the password (self-scoped inside the action).
+  @Method
+  isAllowedWhilePasswordExpired(actionName?: string): boolean {
+    if (!actionName) return false;
+    return ['users.me', 'auth.logout', 'usersLocal.updateUser'].includes(actionName);
   }
 
   @Action({

--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -590,4 +590,13 @@ export default class AuthService extends moleculer.Service {
       this.broker.fatal("Environment variable 'JWT_SECRET' must be configured!");
     }
   }
+
+  async started() {
+    // Drop parseToken results cached by a previous build — they predate this
+    // deploy and lack `passwordMustChange`, which would otherwise let an expired
+    // admin slip past the gate for up to the cache TTL right after rollout.
+    if (this.broker.cacher) {
+      await this.broker.cacher.clean('auth.parseToken**');
+    }
+  }
 }

--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -293,6 +293,15 @@ export default class AuthService extends moleculer.Service {
       userId: result.id,
     });
 
+    // Carried on ctx.meta.user so the API gate can lock expired admins to the
+    // password-change flow. Cached with this result (1h) and invalidated by
+    // usersLocal on password change, so unlocking is immediate.
+    result.passwordMustChange = await ctx.call('usersLocal.passwordMustChange', {
+      userId: result.id,
+      type: result.type,
+      strategy: result.strategy,
+    });
+
     return result;
   }
 

--- a/services/users.service.ts
+++ b/services/users.service.ts
@@ -40,6 +40,7 @@ export interface User extends BaseModelInterface {
   inheritedApps?: App[];
   personalCode?: string;
   fullName: string;
+  passwordMustChange?: boolean;
 }
 
 @Service({
@@ -327,7 +328,12 @@ export default class UsersService extends moleculer.Service {
         populate: ['permissions', 'municipalities'],
       });
       const userInner: any = await getInnerUser(typeId, type);
-      return { ...userInner, ...user };
+      const passwordMustChange: boolean = await ctx.call('usersLocal.passwordMustChange', {
+        userId: id,
+        type: user.type,
+        strategy: type,
+      });
+      return { ...userInner, ...user, passwordMustChange };
     }
   }
 

--- a/services/usersLocal.service.ts
+++ b/services/usersLocal.service.ts
@@ -637,10 +637,20 @@ export default class UsersLocalService extends moleculer.Service {
   // After a password change, drop the cached `auth.parseToken` results so the
   // `passwordMustChange` flag (computed there, cached 1h) refreshes on the next
   // request — otherwise the user stays locked for up to the cache TTL.
+  //
+  // Only an admin's password change can flip that flag, so the (global) flush is
+  // limited to admin targets. This stops a low-privilege USER from triggering a
+  // system-wide auth-cache flush by spamming their own password change (CWE-770).
   @Method
-  cleanAuthCacheOnPasswordChange(ctx: Context<{ password?: string }>, res: any) {
-    if (ctx.params.password && this.broker.cacher) {
-      this.broker.cacher.clean('auth.parseToken**');
+  async cleanAuthCacheOnPasswordChange(ctx: Context<{ password?: string }>, res: any) {
+    if (!ctx.params.password || !this.broker.cacher) return res;
+
+    const userId = typeof res?.user === 'number' ? res.user : res?.user?.id;
+    if (userId) {
+      const user: User = await this.broker.call('users.resolve', { id: userId });
+      if (user?.type === UserType.ADMIN || user?.type === UserType.SUPER_ADMIN) {
+        this.broker.cacher.clean('auth.parseToken**');
+      }
     }
     return res;
   }

--- a/services/usersLocal.service.ts
+++ b/services/usersLocal.service.ts
@@ -20,9 +20,10 @@ import {
   emailCanBeSent,
   generateHashAndSignatureQueryParams,
   generateUUID,
+  isPasswordExpired,
   sendUserInvitationEmail,
 } from '../utils';
-import { AppAuthMeta, UserAuthMeta } from './api.service';
+import { AppAuthMeta, AuthStrategy, UserAuthMeta } from './api.service';
 import { App } from './apps.service';
 import { UserGroupRole } from './userGroups.service';
 import { User, UserType } from './users.service';
@@ -32,6 +33,7 @@ export interface UserLocal extends BaseModelInterface {
   userId?: number;
   email: string;
   password: string;
+  lastPasswordChangeAt?: Date | string;
 }
 
 @Service({
@@ -94,6 +96,11 @@ export interface UserLocal extends BaseModelInterface {
         },
       },
 
+      lastPasswordChangeAt: {
+        type: 'date',
+        columnType: 'datetime',
+      },
+
       ...COMMON_FIELDS,
     },
 
@@ -108,6 +115,10 @@ export interface UserLocal extends BaseModelInterface {
     before: {
       invite: 'validateIfDataIsValid',
       updateUser: ['validateIfDataIsValid', 'validateIfAuthorized'],
+      update: 'stampPasswordChangedAt',
+    },
+    after: {
+      update: 'cleanAuthCacheOnPasswordChange',
     },
   },
 })
@@ -411,6 +422,18 @@ export default class UsersLocalService extends moleculer.Service {
 
     const { meta } = ctx;
 
+    // A logged-in admin whose password is expired is locked to changing their
+    // OWN password — they must not act on other users until they rotate. The
+    // api.service gate already blocks every other action; this stops the one
+    // allow-listed action (updateUser) from being aimed at someone else.
+    if (meta.user?.passwordMustChange && id !== meta.user.id) {
+      throw new moleculer.Errors.MoleculerClientError(
+        'Password change required.',
+        403,
+        'PASSWORD_CHANGE_REQUIRED',
+      );
+    }
+
     const userLocal: UserLocal = await ctx.call('usersLocal.findOne', {
       query: { user: id },
     });
@@ -564,6 +587,32 @@ export default class UsersLocalService extends moleculer.Service {
     return user.id;
   }
 
+  // Whether the given user must rotate their password before they can use the
+  // system. Single source of truth for both the API gate (auth.parseToken) and
+  // the /me response (users.getAuthUser). Only admins with a local password are
+  // subject to the policy — everyone else short-circuits to false (no DB read).
+  @Action({
+    params: {
+      userId: 'number|convert',
+      type: 'string',
+      strategy: 'string',
+    },
+  })
+  async passwordMustChange(
+    ctx: Context<{ userId: number; type: UserType; strategy: AuthStrategy }>,
+  ) {
+    const { userId, type, strategy } = ctx.params;
+
+    const isAdmin = type === UserType.ADMIN || type === UserType.SUPER_ADMIN;
+    if (!isAdmin || strategy !== AuthStrategy.LOCAL) return false;
+
+    const userLocal: UserLocal = await ctx.call('usersLocal.findOne', {
+      query: { user: userId },
+    });
+
+    return isPasswordExpired(userLocal?.lastPasswordChangeAt);
+  }
+
   @Method
   encryptPassword(password: string) {
     return bcrypt.hashSync(password, 10);
@@ -572,6 +621,28 @@ export default class UsersLocalService extends moleculer.Service {
   @Method
   isPasswordValid(hashedPassword: string, password: string) {
     return bcrypt.compare(hashedPassword, password);
+  }
+
+  // Stamp the rotation clock whenever a new password is written. Invite-set,
+  // reset and self-service change all funnel through `update` with `password`,
+  // so a single before-hook covers every path.
+  @Method
+  stampPasswordChangedAt(ctx: Context<{ password?: string; lastPasswordChangeAt?: Date }>) {
+    if (ctx.params.password) {
+      ctx.params.lastPasswordChangeAt = new Date();
+    }
+    return ctx;
+  }
+
+  // After a password change, drop the cached `auth.parseToken` results so the
+  // `passwordMustChange` flag (computed there, cached 1h) refreshes on the next
+  // request — otherwise the user stays locked for up to the cache TTL.
+  @Method
+  cleanAuthCacheOnPasswordChange(ctx: Context<{ password?: string }>, res: any) {
+    if (ctx.params.password && this.broker.cacher) {
+      this.broker.cacher.clean('auth.parseToken**');
+    }
+    return res;
   }
 
   @Method

--- a/test/unit/password.spec.ts
+++ b/test/unit/password.spec.ts
@@ -1,0 +1,40 @@
+'use strict';
+import { describe, expect, it } from '@jest/globals';
+import { isPasswordExpired } from '../../utils/password';
+import { PASSWORD_MAX_AGE_DAYS } from '../../types/constants';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const daysAgo = (days: number) => new Date(Date.now() - days * DAY_MS);
+
+describe('isPasswordExpired', () => {
+  it('treats a missing timestamp as expired (fail closed)', () => {
+    expect(isPasswordExpired(null)).toBe(true);
+    expect(isPasswordExpired(undefined)).toBe(true);
+  });
+
+  it('treats an unparseable timestamp as expired (fail closed)', () => {
+    expect(isPasswordExpired('not-a-date')).toBe(true);
+  });
+
+  it('is not expired for a freshly set password', () => {
+    expect(isPasswordExpired(new Date())).toBe(false);
+  });
+
+  it(`is not expired just under ${PASSWORD_MAX_AGE_DAYS} days`, () => {
+    expect(isPasswordExpired(daysAgo(PASSWORD_MAX_AGE_DAYS - 1))).toBe(false);
+  });
+
+  it(`is expired at and beyond ${PASSWORD_MAX_AGE_DAYS} days`, () => {
+    expect(isPasswordExpired(daysAgo(PASSWORD_MAX_AGE_DAYS + 1))).toBe(true);
+  });
+
+  it('accepts ISO date strings', () => {
+    expect(isPasswordExpired(daysAgo(200).toISOString())).toBe(true);
+    expect(isPasswordExpired(daysAgo(1).toISOString())).toBe(false);
+  });
+
+  it('honours a custom max age', () => {
+    expect(isPasswordExpired(daysAgo(10), 30)).toBe(false);
+    expect(isPasswordExpired(daysAgo(40), 30)).toBe(true);
+  });
+});

--- a/types/constants.ts
+++ b/types/constants.ts
@@ -8,6 +8,9 @@ export enum EndpointType {
   PUBLIC = 'PUBLIC',
 }
 
+// Admin/super-admin local passwords must be rotated at least this often.
+export const PASSWORD_MAX_AGE_DAYS = 90;
+
 export function throwUnauthorizedError(message?: string, data?: any): Errors.MoleculerError {
   throw new Moleculer.Errors.MoleculerClientError(
     message || `Unauthorized.`,

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -2,6 +2,7 @@ export * from './tokens';
 export * from './hashes';
 export * from './mails';
 export * from './recaptcha';
+export * from './password';
 
 export const normalizeName = (words: string) => {
   if (!words) return;

--- a/utils/password.ts
+++ b/utils/password.ts
@@ -1,0 +1,15 @@
+import { PASSWORD_MAX_AGE_DAYS } from '../types/constants';
+
+// True when a local password is older than the rotation window, or has never
+// been stamped (NULL/invalid) — the latter is treated as expired so we fail
+// closed. Pure and side-effect free so it can be unit-tested in isolation.
+export const isPasswordExpired = (
+  lastPasswordChangeAt: Date | string | null | undefined,
+  maxAgeDays: number = PASSWORD_MAX_AGE_DAYS,
+): boolean => {
+  if (!lastPasswordChangeAt) return true;
+  const changedAtMs = new Date(lastPasswordChangeAt).getTime();
+  if (Number.isNaN(changedAtMs)) return true;
+  const ageDays = (Date.now() - changedAtMs) / (1000 * 60 * 60 * 24);
+  return ageDays >= maxAgeDays;
+};


### PR DESCRIPTION
## Ką daro

Admins (`ADMIN` / `SUPER_ADMIN`) su **lokaliu** slaptažodžiu privalo jį keisti kas **90 dienų**. Kol nepasikeitė — `passwordMustChange=true` ir backend'as juos užrakina tik į slaptažodžio keitimo srautą. `eVartai` ir `USER` paskyroms politika netaikoma.

## Pakeitimai (backend, biip-auth-api)

| Sritis | Pakeitimas |
|---|---|
| Migracija | `usersLocal.lastPasswordChangeAt` (nullable), backfill `= createdAt` → esami adminai keičia per pirmą prisijungimą |
| Stamp | `lastPasswordChangeAt = now()` kiekvieną slaptažodžio rašymą (invite/reset/change) — centralizuotas `update` before-hook |
| Flag | `passwordMustChange` apskaičiuojamas `usersLocal.passwordMustChange` (vienintelis šaltinis), grąžinamas `/users/me` ir `ctx.meta.user` (`auth.parseToken`) |
| Gate | `api.service.authorize`: kol pasenęs, atmeta **visus** veiksmus išskyrus `users.me`, `auth.logout`, self-scoped `usersLocal.updateUser` → `403 PASSWORD_CHANGE_REQUIRED` (fail-closed) |
| Cache | po ADMIN slaptažodžio keitimo ir per boot išvalomas `auth.parseToken` cache → atrakinimas momentinis, jokio post-deploy lango |
| Period | konstanta `PASSWORD_MAX_AGE_DAYS = 90` |

## Verifikacija

- ✅ `tsc --noEmit` (0 klaidų), `eslint` (švaru)
- ✅ unit testas `isPasswordExpired` (7/7)
- ✅ `migration-reviewer`: SAFE TO DEPLOY (1×P2 idempotency guard — praleista, nes `hasColumn` po `knexSnakeCaseMappers` nepatikimas, migracijos vyksta vieną kartą)
- ✅ `security-auditor`: 0×P0; P1-1 ir P2-1 ištaisyti; P2-2/P2-3 priimti (nuosava paskyra, jokios eskalacijos)
- ⏳ Integraciniai + live verifikacija (login → priverstinai profilis → keitimas → atrakinta + 403) — verifikacijos etape su paleista aplinka

## ⚠️ Release strategija — NEMERGINTI dar

Ši šaka sukurta **nuo prod tago `1.4.0`** (ne nuo main), kad į prod patektų **tik** ši funkcija. Pora su `biip-admin-web` PR. 

**Tvarka:** (1) verifikuoti → (2) release tagas iš šios šakos → prod deploy → (3) **tik tada** merge į `main`. Deploy žingsnis dar aptariamas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)