### PR TITLE
auth: allow service-to-service userGroups.assign via app key

### DIFF
--- a/services/userGroups.service.ts
+++ b/services/userGroups.service.ts
@@ -283,7 +283,16 @@ export default class UserGroupsService extends moleculer.Service {
       path: '/assign',
       basePath: '/users/:user/groups/:group',
     },
-    types: [EndpointType.ADMIN, EndpointType.SUPER_ADMIN],
+    // Unlike `unassign` (which authorizes by group-admin membership in its body),
+    // `assign` keeps a type gate widened with APP. It HAS in-process broker callers
+    // — usersEvartai company auto-join / defaultGroupId on login, and
+    // users.assignNewGroupsToUser — where the subject is not yet a group-admin, so
+    // a body ownership check would 401 legitimate logins. Internal broker calls
+    // bypass the gateway (and thus this gate) entirely; APP only widens the HTTP
+    // path so the tenant apps' service-to-service assignToGroup (valid app key,
+    // acting user is UserType.USER) is allowed while a browser (no app key) is not.
+    // The calling app authorizes the membership change on its side before calling.
+    types: [EndpointType.ADMIN, EndpointType.SUPER_ADMIN, EndpointType.APP],
     params: {
       user: {
         type: 'number',

--- a/services/users.service.ts
+++ b/services/users.service.ts
@@ -466,9 +466,14 @@ export default class UsersService extends moleculer.Service {
       types: { type: 'array', items: 'string', enum: Object.values(EndpointType) },
     },
   })
-  async validateType(ctx: Context<{ types: EndpointType[] }, UserAuthMeta>) {
+  async validateType(ctx: Context<{ types: EndpointType[] }, UserAuthMeta & AppAuthMeta>) {
     const types = ctx.params.types;
     if (types.includes(EndpointType.PUBLIC)) return true;
+
+    // Service-to-service: an endpoint typed APP is reachable by a trusted backend
+    // holding a valid app API key (X-API-Key -> ctx.meta.app). A browser never
+    // holds an app key, so this never widens the public surface.
+    if (types.includes(EndpointType.APP) && ctx.meta?.app?.id) return true;
 
     const userType = ctx.meta?.user?.type;
     const isAdmin = [UserType.ADMIN].includes(userType);

--- a/test/integration/api/security.spec.ts
+++ b/test/integration/api/security.spec.ts
@@ -332,4 +332,39 @@ describe('Security hardening', () => {
       });
     });
   });
+
+  // `assign` has in-process login/invite callers (company auto-join,
+  // defaultGroupId, assignNewGroupsToUser) whose subject is not yet a
+  // group-admin, so it cannot move authorization into its body like `unassign`.
+  // Instead it is typed APP: a trusted service holding a valid app key may call
+  // it (the tenant apps' assignToGroup, acting user = UserType.USER); a browser,
+  // which never holds an app key, still cannot. Internal broker calls bypass the
+  // gateway and are unaffected.
+  describe('userGroups.assign is service-callable with a valid app key (APP type)', () => {
+    const assign = (userId: number, groupId: number, token: string, apiKey?: string | boolean) =>
+      request(apiService.server)
+        .post(`/api/users/${userId}/groups/${groupId}/assign`)
+        .set(apiHelper.getHeaders(token, apiKey))
+        .send({ role: 'USER' });
+
+    it('a UserType.USER caller with a valid app key can assign (service-to-service)', () => {
+      return assign(
+        apiHelper.fisherUser.id,
+        apiHelper.groupFishersCompany.id,
+        apiHelper.fisherUserToken,
+        apiHelper.appFishing.apiKey,
+      ).expect(200);
+    });
+
+    it('the same caller without an app key (browser) is still refused', () => {
+      return assign(
+        apiHelper.fisherUser.id,
+        apiHelper.groupFishersCompany.id,
+        apiHelper.fisherUserToken,
+        false,
+      ).expect((res: any) => {
+        expect([401, 403]).toContain(res.status);
+      });
+    });
+  });
 });

--- a/types/constants.ts
+++ b/types/constants.ts
@@ -6,6 +6,10 @@ export enum EndpointType {
   USER = 'USER',
   SUPER_ADMIN = 'SUPER_ADMIN',
   PUBLIC = 'PUBLIC',
+  // A trusted service presenting a valid app API key (X-API-Key). Reachable only
+  // service-to-service (a browser never holds an app key), so it widens a gate
+  // for backend callers without exposing the endpoint to the public web.
+  APP = 'APP',
 }
 
 // Admin/super-admin local passwords must be rotated at least this often.


### PR DESCRIPTION
## What
Add `EndpointType.APP` and allow `userGroups.assign` (`POST /api/users/:user/groups/:group/assign`) for a trusted service presenting a valid app API key. Tenant apps can again add members, change roles, and provision membership on login.

## Why
`assign` was gated `[ADMIN, SUPER_ADMIN]` (bf62cff), but the tenant apps call it over HTTP through `biip-auth-nodejs`, forwarding the acting user's token — and company managers / hunters authenticate as `UserType.USER`, so every membership mutation 401'd.

Real symptom (prod): an eVartai user who is in an auth group but whose tenant row was removed could no longer log in — "Nesuteikta prieiga" — because `afterUserLoggedIn` re-provisioning hit the 401. The same 401 breaks tenant-admin add/role-change and left auth memberships behind on removal (desync). Affects medziokle, zvejyba, zuvinimas, gyvunai, rusys, uetk, NTIS.

## Notes
- `APP` is satisfied only when a valid `X-API-Key` resolved to `ctx.meta.app`. Browsers never send an app key, so the public surface is unchanged — regression test included (USER + app key -> 200; USER without key -> refused).
- `assign` keeps a widened type gate rather than `unassign`'s body ownership check because it has in-process login callers (company auto-join / defaultGroupId / `assignNewGroupsToUser`) that a body ownership check would 401. Internal broker calls bypass the gateway and are unaffected.
- No tenant-module change needed — they already send the app key on these calls.