### PR TITLE
auth: let company managers invite and remove members (membership authz)

### DIFF
--- a/services/userGroups.service.ts
+++ b/services/userGroups.service.ts
@@ -339,7 +339,7 @@ export default class UserGroupsService extends moleculer.Service {
       path: '/unassign',
       basePath: '/users/:user/groups/:group',
     },
-    // AuthZ by group-admin membership, not global UserType. External company
+    // AuthZ by group membership, not global UserType. External company
     // managers land in auth as UserType.USER (eVartai users default to USER), so
     // a blunt [ADMIN, SUPER_ADMIN] gate 401'd them: tenant apps could ADD a member
     // (via users.invite, which self-authorizes and assigns over an internal broker
@@ -362,15 +362,16 @@ export default class UserGroupsService extends moleculer.Service {
     const { user, group } = ctx.params;
     const { meta } = ctx;
 
-    // getVisibleGroupsIds({edit:true}) returns, scoped to the calling app: every
-    // app group for SUPER_ADMIN, app companies for ADMIN, the groups the caller is
-    // group-ADMIN of for a USER, and all app groups for an app-key-only call.
-    const editableGroupIds: any[] = await ctx.call(
-      'permissions.getVisibleGroupsIds',
-      { edit: true },
-      { meta },
-    );
-    if (!editableGroupIds?.map(Number).includes(Number(group))) {
+    // Membership (any role), NOT group-ADMIN — same contract as the
+    // usersEvartai.invite guard. Tenant apps map their manager roles (e.g.
+    // zvejyba USER_ADMIN) to auth group-USER — auth's two-role group model
+    // cannot express them — and each app authorizes who may manage members
+    // before calling. Requiring group-ADMIN here 403'd the removal cascade for
+    // those managers (local row deleted, auth membership lingered, the removed
+    // member got re-provisioned on next login). The cross-company boundary
+    // stays: a caller can never touch a group outside their membership tree.
+    const visibleGroupIds: any[] = await ctx.call('permissions.getVisibleGroupsIds', {}, { meta });
+    if (!visibleGroupIds?.map(Number).includes(Number(group))) {
       throw new moleculer.Errors.MoleculerClientError(
         `Not authorized to modify membership of group '${group}'.`,
         403,

--- a/services/usersEvartai.service.ts
+++ b/services/usersEvartai.service.ts
@@ -413,17 +413,21 @@ export default class UsersEvartaiService extends moleculer.Service {
           throwNotFoundError('Company not found');
         }
 
-        // AuthZ: only assign a person into a company the caller may administer.
-        // getVisibleGroupsIds({edit:true}) returns, scoped to the calling app:
-        // every app group for SUPER_ADMIN, otherwise the groups the caller is
-        // ADMIN of. Without this any authenticated USER could add an arbitrary
-        // person into any company (cross-company privilege grant).
-        const editableGroupIds: any[] = await ctx.call(
+        // AuthZ: only assign a person into a company the caller belongs to.
+        // Membership (any role), NOT group-ADMIN: tenant apps map their manager
+        // roles (e.g. zvejyba USER_ADMIN) to auth group-USER — this two-role
+        // group model cannot express them — and each app authorizes who may
+        // manage members before calling. Requiring group-ADMIN here 403'd every
+        // USER_ADMIN invite in prod (AUTH_UNAUTHORIZED_COMPANY). The check that
+        // matters stays: a caller cannot reach a company outside their own
+        // membership tree (cross-company privilege grant), and ADMIN /
+        // SUPER_ADMIN / app-key-only callers keep their app-wide visibility.
+        const visibleGroupIds: any[] = await ctx.call(
           'permissions.getVisibleGroupsIds',
-          { edit: true },
+          {},
           { meta },
         );
-        if (!editableGroupIds?.map(Number).includes(Number(companyId))) {
+        if (!visibleGroupIds?.map(Number).includes(Number(companyId))) {
           throw new moleculer.Errors.MoleculerClientError(
             `Not authorized to assign users to company '${companyId}'.`,
             403,

--- a/test/integration/api/security.spec.ts
+++ b/test/integration/api/security.spec.ts
@@ -79,8 +79,12 @@ describe('Security hardening', () => {
     });
   });
 
-  // P1-6: assigning a person into a company requires admin rights on that
-  // company. A group member who is not its admin must be refused.
+  // P1-6 (revised): assigning a person into a company requires MEMBERSHIP of
+  // that company, not group-ADMIN. Tenant apps map their manager roles (e.g.
+  // zvejyba USER_ADMIN) to auth group-USER and authorize member management on
+  // their side before calling; requiring group-ADMIN here 403'd every
+  // USER_ADMIN invite in prod. The boundary that stays is cross-company:
+  // a caller can never reach a company outside their membership tree.
   describe('cross-company invite guard', () => {
     it('company admin can assign a person to their company', () => {
       return request(apiService.server)
@@ -94,7 +98,7 @@ describe('Security hardening', () => {
         .expect(200);
     });
 
-    it('non-admin group member cannot assign a person to the company', () => {
+    it('a non-admin member can assign a person to their own company (tenant-app managers)', () => {
       return request(apiService.server)
         .post('/api/users/invite')
         .set(apiHelper.getHeaders(apiHelper.fisherUserToken, apiHelper.appFishing.apiKey))
@@ -103,10 +107,7 @@ describe('Security hardening', () => {
           companyId: apiHelper.groupFishersCompany.id,
           throwErrors: false,
         })
-        .expect((res: any) => {
-          expect([401, 403]).toContain(res.status);
-          expect(res.body.type).toEqual('AUTH_UNAUTHORIZED_COMPANY');
-        });
+        .expect(200);
     });
 
     it('company admin cannot assign into a company of another app', () => {
@@ -281,19 +282,25 @@ describe('Security hardening', () => {
     });
   });
 
-  // Removing a company member must authorize by GROUP-admin membership, not global
-  // UserType. External company managers are UserType.USER (eVartai default), so the
-  // old [ADMIN, SUPER_ADMIN] gate on userGroups.unassign 401'd them — tenant apps
-  // could invite a member but never remove one (local row deleted, auth membership
-  // left dangling). This mirrors the usersEvartai.invite authz.
-  describe('group-admin can unassign a member (invite parity)', () => {
+  // Removing a company member must authorize by group MEMBERSHIP, not global
+  // UserType and not group-ADMIN. External company managers are UserType.USER
+  // (eVartai default) and tenant-app manager roles (e.g. zvejyba USER_ADMIN) map
+  // to auth group-USER, so any stricter gate 403'd the tenant apps' removal
+  // cascade — local row deleted, auth membership left dangling, ghost member
+  // re-provisioned on next login. This mirrors the usersEvartai.invite authz:
+  // the boundary auth enforces is cross-company, the role policy is the app's.
+  describe('company member can unassign a member (invite parity)', () => {
     const unassign = (userId: number, groupId: number, token: string) =>
       request(apiService.server)
         .post(`/api/users/${userId}/groups/${groupId}/unassign`)
         .set(apiHelper.getHeaders(token, apiHelper.appFishing.apiKey));
 
     it('a group-ADMIN (UserType.USER) can unassign a member of their company', async () => {
-      await unassign(apiHelper.fisherUser.id, apiHelper.groupFishersCompany.id, apiHelper.fisherToken)
+      await unassign(
+        apiHelper.fisherUser.id,
+        apiHelper.groupFishersCompany.id,
+        apiHelper.fisherToken,
+      )
         .expect(200)
         .expect((res: any) => expect(res.body.success).toEqual(true));
 
@@ -310,15 +317,41 @@ describe('Security hardening', () => {
       });
     });
 
-    it('a non-admin group member cannot unassign', () => {
-      return unassign(
+    it('a non-admin member can unassign within their own company (tenant-app managers)', async () => {
+      await unassign(
         apiHelper.fisher.id,
         apiHelper.groupFishersCompany.id,
         apiHelper.fisherUserToken,
-      ).expect((res: any) => {
-        expect([401, 403]).toContain(res.status);
-        expect(res.body.type).toEqual('AUTH_UNAUTHORIZED_GROUP');
+      )
+        .expect(200)
+        .expect((res: any) => expect(res.body.success).toEqual(true));
+
+      const membership = await broker.call('userGroups.findOne', {
+        query: { user: apiHelper.fisher.id, group: apiHelper.groupFishersCompany.id },
       });
+      expect(membership).toBeFalsy();
+
+      // restore fixture state so ordering can't couple to this suite
+      await broker.call('userGroups.create', {
+        user: apiHelper.fisher.id,
+        group: apiHelper.groupFishersCompany.id,
+        role: 'ADMIN',
+      });
+    });
+
+    it('a member cannot unassign from a same-app company they do not belong to', async () => {
+      const otherCompany: any = await broker.call('groups.create', {
+        name: 'Other Fishers Company (unassign)',
+        apps: [apiHelper.appFishing.id],
+        companyCode: '300000003',
+      });
+
+      return unassign(apiHelper.fisher.id, otherCompany.id, apiHelper.fisherUserToken).expect(
+        (res: any) => {
+          expect([401, 403]).toContain(res.status);
+          expect(res.body.type).toEqual('AUTH_UNAUTHORIZED_GROUP');
+        },
+      );
     });
 
     it('a group-ADMIN cannot unassign from a company of another app', () => {

--- a/test/integration/api/users/users.invite.spec.ts
+++ b/test/integration/api/users/users.invite.spec.ts
@@ -253,6 +253,49 @@ describe("Test POST '/api/users/invite'", () => {
   });
 
   describe('Acting as fisher', () => {
+    // Tenant apps map their manager roles (e.g. zvejyba USER_ADMIN) to auth
+    // group-USER — auth's two-role group model cannot express them. The app
+    // authorizes who may manage members BEFORE calling users.invite, so auth
+    // must accept any member of the target company here and only enforce the
+    // cross-company boundary. Regression: PR #49 required group-ADMIN and
+    // 403'd every USER_ADMIN invite (AUTH_UNAUTHORIZED_COMPANY in prod).
+    describe('Invite person into a company (personalCode + companyId)', () => {
+      it('a non-admin member of the company can invite into it (success)', () => {
+        return request(apiService.server)
+          .post(endpoint)
+          .set(apiHelper.getHeaders(apiHelper.fisherUserToken, apiHelper.appFishing.apiKey))
+          .send({
+            personalCode: '91234567892',
+            companyId: apiHelper.groupFishersCompany.id,
+          })
+          .expect(200)
+          .expect((res: any) => {
+            expect(res.body.personalCode).toEqual('91234567892');
+            expect(res.body.role).toEqual('USER');
+          });
+      });
+
+      it('cannot invite into a same-app company they are not a member of (fail)', async () => {
+        const otherCompany: any = await broker.call('groups.create', {
+          name: 'Other Fishers Company',
+          apps: [apiHelper.appFishing.id],
+          companyCode: '112332965',
+        });
+
+        return request(apiService.server)
+          .post(endpoint)
+          .set(apiHelper.getHeaders(apiHelper.fisherUserToken, apiHelper.appFishing.apiKey))
+          .send({
+            personalCode: '91234567893',
+            companyId: otherCompany.id,
+          })
+          .expect(403)
+          .expect((res: any) => {
+            expect(res.body.type).toEqual('AUTH_UNAUTHORIZED_COMPANY');
+          });
+      });
+    });
+
     describe('Invite company with parent company', () => {
       it('With fishing group parent (success)', async () => {
         const companyCode = '196541141';


### PR DESCRIPTION
## What
`users.invite` (personalCode + companyId) and `userGroups.unassign` now authorize by **membership of the target company** (any role) instead of requiring auth-side group-ADMIN. Tenant-app company managers can again add and remove members.

## Why
#49 gated both paths on `getVisibleGroupsIds({edit:true})` (group-ADMIN only). But tenant apps map their manager roles to auth group-USER (zvejyba: only OWNER → ADMIN, USER_ADMIN → USER), so in prod every USER_ADMIN invite failed with `AUTH_UNAUTHORIZED_COMPANY` (zvejyba `tenantUsers/invite`), and member removal desynced: the local row was deleted while the auth membership lingered, re-provisioning the ghost member on next login. Auth's two-role group model cannot express those manager roles — the tenant app authorizes member management before calling (same trust model as #55); auth keeps enforcing the cross-company boundary.

## Notes
- Cross-company protection is regression-tested both ways: same-app foreign company and cross-app company still 403 (`AUTH_UNAUTHORIZED_COMPANY` / `AUTH_UNAUTHORIZED_GROUP`).
- Full suite green: 21/21 suites, 269/269 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)